### PR TITLE
Ac 1456 attachments v2

### DIFF
--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.3
+### Rework Attachments
+  * Deprecated old call to generate an upload url
+  * Uploading Thumbnails for Images
+  * Scaling down images to have a maximum side of 1000px
+
 ## 0.9.2
 * Add call to upload Profile Picture
 * Hide `ContentType` in export of Network Package

--- a/packages/apptive_grid_core/lib/apptive_grid_network.dart
+++ b/packages/apptive_grid_core/lib/apptive_grid_network.dart
@@ -2,15 +2,11 @@ library apptive_grid_network;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
-import 'package:apptive_grid_core/apptive_grid_model.dart';
 import 'package:apptive_grid_core/apptive_grid_options.dart';
 import 'package:apptive_grid_core/network/authentication/authentication_storage.dart';
 import 'package:apptive_grid_core/network/authentication/io_authenticator.dart'
     if (dart.library.html) 'package:apptive_grid_core/network/authentication/web_authenticator.dart';
-import 'package:apptive_grid_core/network/filter/apptive_grid_filter.dart';
-import 'package:apptive_grid_core/network/sorting/apptive_grid_sorting.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
@@ -22,7 +18,7 @@ export 'package:apptive_grid_core/network/authentication/web_auth_enabler/web_au
 export 'package:apptive_grid_core/network/sorting/apptive_grid_sorting.dart';
 export 'package:apptive_grid_core/network/filter/apptive_grid_filter.dart';
 
-part 'network/apptive_grid_client.dart';
+export 'network/apptive_grid_client.dart';
 
 part 'network/authentication/apptive_grid_authentication_options.dart';
 

--- a/packages/apptive_grid_core/lib/model/attachment/attachment_configuration.dart
+++ b/packages/apptive_grid_core/lib/model/attachment/attachment_configuration.dart
@@ -14,9 +14,10 @@ class AttachmentConfiguration {
   /// Creates a new AttachmentConfiguration from json
   factory AttachmentConfiguration.fromJson(Map<String, dynamic> json) {
     return AttachmentConfiguration(
-      signedUrlApiEndpoint: json['signedUrl'],
-      signedUrlFormApiEndpoint: json['signedUrlForm'],
-      attachmentApiEndpoint: json['storageUrl'],
+      signedUrlApiEndpoint: json['signedUrlEndpoint'] ?? json['signedUrl'],
+      signedUrlFormApiEndpoint:
+          json['unauthenticatedSignedUrlEndpoint'] ?? json['signedUrlForm'],
+      attachmentApiEndpoint: json['apiEndpoint'] ?? json['storageUrl'],
     );
   }
 

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -516,7 +516,8 @@ class ApptiveGridClient {
   }
 
   /// Creates an url where an attachment should be saved
-  @Deprecated('Use AttachmentClient.createAttachment')
+  /// Deprecated: use [ApptiveGridClient.attachmentProcessor.createAttachment]
+  @Deprecated('Use attachmentProcessor.createAttachment')
   Uri createAttachmentUrl(String name) {
     return Uri.parse(
       '$_attachmentApiEndpoint$name?${DateTime.now().millisecondsSinceEpoch}',

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -22,29 +22,30 @@ class ApptiveGridClient {
   /// Creates an ApiClient
   ApptiveGridClient({
     this.options = const ApptiveGridOptions(),
-  })  : _client = http.Client(),
-        _authenticator = ApptiveGridAuthenticator(options: options) {
-    _attachmentProcessor = AttachmentProcessor(options, _authenticator);
+    http.Client? httpClient,
+    ApptiveGridAuthenticator? authenticator,
+  })  : _client = httpClient ?? http.Client() {
+    _authenticator = authenticator ?? ApptiveGridAuthenticator(options: options, httpClient: _client);
+    _attachmentProcessor = AttachmentProcessor(options, _authenticator, httpClient: _client);
   }
 
   /// Creates an Api Client on the Basis of a [http.Client]
   ///
   /// this should only be used for testing in order to pass in a Mocked [http.Client]
   @visibleForTesting
-  ApptiveGridClient.fromClient(
+  @Deprecated('httpClient now is an argument in the unnamed constructor')
+  factory ApptiveGridClient.fromClient(
     http.Client httpClient, {
-    this.options = const ApptiveGridOptions(),
+    ApptiveGridOptions options = const ApptiveGridOptions(),
     ApptiveGridAuthenticator? authenticator,
-  })  : _client = httpClient,
-        _authenticator = authenticator ??
-            ApptiveGridAuthenticator(options: options, httpClient: httpClient) {
-    _attachmentProcessor = AttachmentProcessor(options, _authenticator);
+  })  {
+    return ApptiveGridClient(options: options, authenticator: authenticator, httpClient: httpClient);
   }
 
   /// Configurations
   ApptiveGridOptions options;
 
-  final ApptiveGridAuthenticator _authenticator;
+  late final ApptiveGridAuthenticator _authenticator;
 
   final http.Client _client;
 

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -1,4 +1,21 @@
-part of apptive_grid_network;
+library apptive_grid_client;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:apptive_grid_core/apptive_grid_model.dart';
+import 'package:apptive_grid_core/apptive_grid_network.dart';
+import 'package:apptive_grid_core/apptive_grid_options.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:mime/mime.dart';
+import 'package:openid_client/openid_client.dart';
+import 'package:uuid/uuid.dart';
+import 'package:image/image.dart' as img;
+import 'dart:math' as math;
+
+part 'attachment_client.dart';
 
 /// Api Client to communicate with the ApptiveGrid Backend
 class ApptiveGridClient {
@@ -6,7 +23,9 @@ class ApptiveGridClient {
   ApptiveGridClient({
     this.options = const ApptiveGridOptions(),
   })  : _client = http.Client(),
-        _authenticator = ApptiveGridAuthenticator(options: options);
+        _authenticator = ApptiveGridAuthenticator(options: options) {
+    _attachmentProcessor = AttachmentProcessor(options, _authenticator);
+  }
 
   /// Creates an Api Client on the Basis of a [http.Client]
   ///
@@ -18,7 +37,9 @@ class ApptiveGridClient {
     ApptiveGridAuthenticator? authenticator,
   })  : _client = httpClient,
         _authenticator = authenticator ??
-            ApptiveGridAuthenticator(options: options, httpClient: httpClient);
+            ApptiveGridAuthenticator(options: options, httpClient: httpClient) {
+    _attachmentProcessor = AttachmentProcessor(options, _authenticator);
+  }
 
   /// Configurations
   ApptiveGridOptions options;
@@ -26,6 +47,9 @@ class ApptiveGridClient {
   final ApptiveGridAuthenticator _authenticator;
 
   final http.Client _client;
+
+  late AttachmentProcessor _attachmentProcessor;
+  AttachmentProcessor get attachmentProcessor => _attachmentProcessor;
 
   /// Close the connection on the httpClient
   void dispose() {
@@ -146,9 +170,8 @@ class ApptiveGridClient {
       actions.values.map((action) {
         switch (action.type) {
           case AttachmentActionType.add:
-            return _uploadAttachment(
+            return _attachmentProcessor.uploadAttachment(
               action as AddAttachmentAction,
-              fromForm: fromForm,
             );
           case AttachmentActionType.delete:
             debugPrint('Delete Attachment ${action.attachment}');
@@ -448,6 +471,7 @@ class ApptiveGridClient {
 
     options = options.copyWith(environment: environment);
     _authenticator.options = options;
+    _attachmentProcessor = AttachmentProcessor(options, _authenticator);
   }
 
   /// Tries to send pending [ActionItem]s that are stored in [options.cache]
@@ -467,24 +491,6 @@ class ApptiveGridClient {
     }
   }
 
-  // Attachments
-  String get _signedUrlApiEndpoint {
-    final endpoint = options
-        .attachmentConfigurations[options.environment]?.signedUrlApiEndpoint;
-    if (endpoint != null) {
-      return endpoint;
-    } else {
-      throw ArgumentError(
-        'In order to use Attachments you need to specify AttachmentConfigurations in ApptiveGridOptions',
-      );
-    }
-  }
-
-  String? get _signedUrlFormApiEndpoint {
-    return options.attachmentConfigurations[options.environment]
-        ?.signedUrlFormApiEndpoint;
-  }
-
   String get _attachmentApiEndpoint {
     final endpoint = options
         .attachmentConfigurations[options.environment]?.attachmentApiEndpoint;
@@ -498,8 +504,7 @@ class ApptiveGridClient {
   }
 
   /// Creates an url where an attachment should be saved
-  ///
-  /// TODO: Do not Use Name
+  @Deprecated('Use AttachmentClient.createAttachment')
   Uri createAttachmentUrl(String name) {
     return Uri.parse(
       '$_attachmentApiEndpoint$name?${DateTime.now().millisecondsSinceEpoch}',
@@ -512,49 +517,6 @@ class ApptiveGridClient {
   ///
   /// In order for no authentication [fromForm] needs to be `true` and [AttachmentConfiguration.signedUrlFormApiEndpoint] needs to be non null
   /// for the current [ApptiveGridStage] in [ApptiveGridOptions.attachmentConfigurations] in [options]
-  Future _uploadAttachment(
-    AddAttachmentAction action, {
-    bool fromForm = false,
-  }) async {
-    final requireAuth = !fromForm || _signedUrlFormApiEndpoint == null;
-    if (requireAuth) {
-      await _authenticator.checkAuthentication();
-    }
-
-    final baseUri = Uri.parse(
-      requireAuth ? _signedUrlApiEndpoint : _signedUrlFormApiEndpoint!,
-    );
-    final uri = Uri(
-      scheme: baseUri.scheme,
-      host: baseUri.host,
-      path: baseUri.path,
-      queryParameters: {
-        'fileName': action.attachment.name,
-        'fileType': action.attachment.type,
-      },
-    );
-    final createUrlHeaders = requireAuth ? headers : <String, String>{};
-    return _client.get(uri, headers: createUrlHeaders).then((response) {
-      if (response.statusCode < 400) {
-        return _client
-            .put(
-          Uri.parse(jsonDecode(response.body)['uploadURL']),
-          headers: {HttpHeaders.contentTypeHeader: action.attachment.type},
-          body: action.byteData,
-        )
-            .then((putResponse) {
-          if (putResponse.statusCode < 400) {
-            debugPrint('Uploaded Successfully');
-            return putResponse;
-          } else {
-            throw putResponse;
-          }
-        });
-      } else {
-        throw response;
-      }
-    });
-  }
 
   /// Uploads [bytes] as the Profile Picture for the logged in user
   Future<http.Response> uploadProfilePicture({required Uint8List bytes}) async {

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -15,7 +15,7 @@ import 'package:uuid/uuid.dart';
 import 'package:image/image.dart' as img;
 import 'dart:math' as math;
 
-part 'attachment_client.dart';
+part 'attachment_processor.dart';
 
 /// Api Client to communicate with the ApptiveGrid Backend
 class ApptiveGridClient {
@@ -24,11 +24,14 @@ class ApptiveGridClient {
     this.options = const ApptiveGridOptions(),
     http.Client? httpClient,
     ApptiveGridAuthenticator? authenticator,
-  })  : _client = httpClient ?? http.Client() {
-    _authenticator = authenticator ?? ApptiveGridAuthenticator(options: options, httpClient: _client);
-    _attachmentProcessor = AttachmentProcessor(options, _authenticator, httpClient: _client);
+  }) : _client = httpClient ?? http.Client() {
+    _authenticator = authenticator ??
+        ApptiveGridAuthenticator(options: options, httpClient: _client);
+    _attachmentProcessor =
+        AttachmentProcessor(options, _authenticator, httpClient: _client);
   }
 
+  // coverage:ignore-start
   /// Creates an Api Client on the Basis of a [http.Client]
   ///
   /// this should only be used for testing in order to pass in a Mocked [http.Client]
@@ -38,9 +41,14 @@ class ApptiveGridClient {
     http.Client httpClient, {
     ApptiveGridOptions options = const ApptiveGridOptions(),
     ApptiveGridAuthenticator? authenticator,
-  })  {
-    return ApptiveGridClient(options: options, authenticator: authenticator, httpClient: httpClient);
+  }) {
+    return ApptiveGridClient(
+      options: options,
+      authenticator: authenticator,
+      httpClient: httpClient,
+    );
   }
+  // coverage:ignore-end
 
   /// Configurations
   ApptiveGridOptions options;
@@ -50,6 +58,7 @@ class ApptiveGridClient {
   final http.Client _client;
 
   late AttachmentProcessor _attachmentProcessor;
+
   AttachmentProcessor get attachmentProcessor => _attachmentProcessor;
 
   /// Close the connection on the httpClient

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -59,6 +59,8 @@ class ApptiveGridClient {
 
   late AttachmentProcessor _attachmentProcessor;
 
+  /// Processor for Attachments.
+  /// Handles uploading attachments, creating attachments, scaling images
   AttachmentProcessor get attachmentProcessor => _attachmentProcessor;
 
   /// Close the connection on the httpClient
@@ -520,13 +522,6 @@ class ApptiveGridClient {
       '$_attachmentApiEndpoint$name?${DateTime.now().millisecondsSinceEpoch}',
     );
   }
-
-  /// Uploads an [Attachment] defined in [action]
-  ///
-  /// [fromForm] determines if this attachment can be added without the need for authentication
-  ///
-  /// In order for no authentication [fromForm] needs to be `true` and [AttachmentConfiguration.signedUrlFormApiEndpoint] needs to be non null
-  /// for the current [ApptiveGridStage] in [ApptiveGridOptions.attachmentConfigurations] in [options]
 
   /// Uploads [bytes] as the Profile Picture for the logged in user
   Future<http.Response> uploadProfilePicture({required Uint8List bytes}) async {

--- a/packages/apptive_grid_core/lib/network/attachment_client.dart
+++ b/packages/apptive_grid_core/lib/network/attachment_client.dart
@@ -1,0 +1,201 @@
+part of apptive_grid_client;
+
+class AttachmentProcessor {
+  AttachmentProcessor(this.options, this.authenticator);
+
+  final ApptiveGridOptions options;
+  final ApptiveGridAuthenticator authenticator;
+  AttachmentConfiguration? _config;
+  static const _uuid = Uuid();
+
+  Future<AttachmentConfiguration> get configuration async {
+    if (_config == null) {
+      final serverResponse = (await http
+          .get(Uri.parse('${options.environment.url}/config.json'))
+          .catchError((error) => http.Response('{}', 400)));
+      final serverAttachments = jsonDecode(serverResponse.body)['attachments'];
+
+      _config = serverAttachments != null
+          ? AttachmentConfiguration.fromJson(serverAttachments)
+          : options.attachmentConfigurations[options.environment];
+    }
+    return _config!;
+  }
+
+  Future<Attachment> createAttachment(String name) async {
+    final type = lookupMimeType(name) ?? '';
+    final config = await configuration;
+
+    final url = _generateUri(config);
+
+    Uri? smallThumbnail;
+    Uri? largeThumbnail;
+
+    if (type.startsWith('image/')) {
+      smallThumbnail = _generateUri(config);
+      largeThumbnail = _generateUri(config);
+    }
+    final attachment = Attachment(
+      name: name,
+      url: url,
+      type: type,
+      smallThumbnail: smallThumbnail,
+      largeThumbnail: largeThumbnail,
+    );
+    return attachment;
+  }
+
+  Uri _generateUri(AttachmentConfiguration configuration) {
+    final id = _uuid.v4();
+
+    final baseUri = Uri.parse(configuration.attachmentApiEndpoint);
+    return baseUri.replace(
+      path: '${baseUri.path}/$id',
+    );
+  }
+
+  Future<http.Response> uploadAttachment(
+    AddAttachmentAction attachmentAction,
+  ) async {
+    final config = await configuration;
+    final authenticated = (await authenticator.isAuthenticated) ||
+        config.signedUrlFormApiEndpoint == null;
+
+    if (authenticated) {
+      await authenticator.checkAuthentication();
+    }
+
+    final baseUploadUri = Uri.parse(
+      authenticated
+          ? config.signedUrlApiEndpoint
+          : config.signedUrlFormApiEndpoint!,
+    );
+    final uploadHeaders = authenticated
+        ? {
+            HttpHeaders.authorizationHeader: authenticator.header!,
+          }
+        : <String, String>{};
+
+    if (attachmentAction.attachment.type.startsWith('image')) {
+      final type = attachmentAction.attachment.type;
+      final uploads = await Future.wait<http.Response>(
+        [
+          _uploadFile(
+            baseUri: baseUploadUri,
+            headers: uploadHeaders,
+            bytes: await _scaleImageToMaxSize(
+              originalImage: attachmentAction.byteData!,
+              size: 1000,
+              type: type,
+            ),
+            name: attachmentAction.attachment.url.pathSegments.last,
+            type: type,
+          ),
+          if (attachmentAction.attachment.largeThumbnail != null)
+            _uploadFile(
+              baseUri: baseUploadUri,
+              headers: uploadHeaders,
+              bytes: await _scaleImageToMaxSize(
+                originalImage: attachmentAction.byteData!,
+                size: 256,
+                type: type,
+              ),
+              name:
+                  attachmentAction.attachment.largeThumbnail!.pathSegments.last,
+              type: type,
+            ),
+          if (attachmentAction.attachment.smallThumbnail != null)
+            _uploadFile(
+              baseUri: baseUploadUri,
+              headers: uploadHeaders,
+              bytes: await _scaleImageToMaxSize(
+                originalImage: attachmentAction.byteData!,
+                size: 64,
+                type: type,
+              ),
+              name:
+                  attachmentAction.attachment.smallThumbnail!.pathSegments.last,
+              type: type,
+            ),
+        ],
+      );
+      return uploads.first;
+    } else {
+      return _uploadFile(
+        baseUri: baseUploadUri,
+        headers: uploadHeaders,
+        bytes: attachmentAction.byteData!,
+        name: attachmentAction.attachment.url.pathSegments.last,
+        type: attachmentAction.attachment.type,
+      );
+    }
+  }
+
+  Future<http.Response> _uploadFile({
+    required Uri baseUri,
+    required Map<String, String> headers,
+    required Uint8List bytes,
+    required String name,
+    required String type,
+  }) async {
+    final uri = baseUri.replace(
+      queryParameters: {
+        'fileName': name,
+        'fileType': type,
+      },
+    );
+
+    final uploadUrlResponse = await http.get(uri, headers: headers);
+
+    if (uploadUrlResponse.statusCode >= 400) {
+      throw uploadUrlResponse;
+    }
+
+    final uploadUrl = Uri.parse(
+      jsonDecode(uploadUrlResponse.body)['uploadURL'],
+    );
+
+    final putResponse = await http.put(
+      uploadUrl,
+      headers: {
+        HttpHeaders.contentTypeHeader: type,
+      },
+      body: bytes,
+    );
+
+    if (putResponse.statusCode >= 400) {
+      throw putResponse;
+    } else {
+      return putResponse;
+    }
+  }
+
+  Future<Uint8List> _scaleImageToMaxSize({
+    required Uint8List originalImage,
+    required int size,
+    required String type,
+  }) async {
+    final resizeData = originalImage;
+    final image = img.decodeImage(resizeData)!;
+    if (math.max(image.width, image.height) <= size) {
+      return originalImage;
+    }
+
+    final isPortrait = image.width < image.height;
+    final widthFactor = isPortrait ? image.width / image.height : 1.0;
+    final heightFactor = isPortrait ? 1.0 : image.height / image.width;
+
+    final resized = img.copyResize(
+      image,
+      width: (size * widthFactor).toInt(),
+      height: (size * heightFactor).toInt(),
+      interpolation: img.Interpolation.average,
+    );
+    return Uint8List.fromList(
+      img.encodeNamedImage(
+        resized,
+        'name.${type.split('/').last}',
+      )!,
+    );
+  }
+}

--- a/packages/apptive_grid_core/pubspec.yaml
+++ b/packages/apptive_grid_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_core
 description: Core Library for ApptiveGrid used to provide general ApptiveGrid functionality to other Packages or Apps
-version: 0.9.2
+version: 0.9.3
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_core
 

--- a/packages/apptive_grid_core/pubspec.yaml
+++ b/packages/apptive_grid_core/pubspec.yaml
@@ -9,12 +9,15 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  image: ^3.1.3
   intl: ^0.17.0
   http: ^0.13.4
+  mime: ^1.0.1
   provider: ^6.0.2
   openid_client: ^0.4.3
   uni_links: ^0.5.1
   url_launcher: ^6.0.17
+  uuid: ^3.0.6
   flutter_secure_storage: ^5.0.2
   flutter:
     sdk: flutter

--- a/packages/apptive_grid_core/test/api_client_test.dart
+++ b/packages/apptive_grid_core/test/api_client_test.dart
@@ -361,17 +361,23 @@ void main() {
             ),
             authenticator: authenticator,
           );
-          when(() => httpClient.get(
+          when(
+            () => httpClient.get(
               any(
-                  that: predicate<Uri>(
-                      (uri) => uri.path.endsWith('config.json'),),),
-              headers: any(named: 'headers'),),).thenAnswer((invocation) async {
+                that: predicate<Uri>(
+                  (uri) => uri.path.endsWith('config.json'),
+                ),
+              ),
+              headers: any(named: 'headers'),
+            ),
+          ).thenAnswer((invocation) async {
             return Response('{}', 200);
           });
         });
 
         test('Create Attachment Uri, throws Error', () {
           expect(
+            // ignore: deprecated_member_use_from_same_package
             () => client.createAttachmentUrl('Name'),
             throwsA(isInstanceOf<ArgumentError>()),
           );
@@ -440,30 +446,40 @@ void main() {
             authenticator: authenticator,
           );
 
-          when(() => httpClient.get(
+          when(
+            () => httpClient.get(
               any(
-                  that: predicate<Uri>(
-                          (uri) => uri.path.endsWith('config.json'),),),
-              headers: any(named: 'headers'),),).thenAnswer((invocation) async {
-            return Response(jsonEncode({
-              'attachments': {
-                "unauthenticatedSignedUrlEndpoint": signedFormUrl,
-                "signedUrlEndpoint": signedUrl,
-                "apiEndpoint": attachmentUrl,
-              }
-            }), 200,);
+                that: predicate<Uri>(
+                  (uri) => uri.path.endsWith('config.json'),
+                ),
+              ),
+              headers: any(named: 'headers'),
+            ),
+          ).thenAnswer((invocation) async {
+            return Response(
+              jsonEncode({
+                'attachments': {
+                  "unauthenticatedSignedUrlEndpoint": signedFormUrl,
+                  "signedUrlEndpoint": signedUrl,
+                  "apiEndpoint": attachmentUrl,
+                }
+              }),
+              200,
+            );
           });
         });
 
         test('Server config is used', () async {
-          expect(await client.attachmentProcessor.configuration, equals(
-            const AttachmentConfiguration(
-              signedUrlApiEndpoint: signedUrl,
-              signedUrlFormApiEndpoint: signedFormUrl,
-              attachmentApiEndpoint: attachmentUrl,
+          expect(
+            await client.attachmentProcessor.configuration,
+            equals(
+              const AttachmentConfiguration(
+                signedUrlApiEndpoint: signedUrl,
+                signedUrlFormApiEndpoint: signedFormUrl,
+                attachmentApiEndpoint: attachmentUrl,
+              ),
             ),
-          ),);
-
+          );
         });
       });
 
@@ -498,11 +514,16 @@ void main() {
             ),
             authenticator: authenticator,
           );
-          when(() => httpClient.get(
+          when(
+            () => httpClient.get(
               any(
-                  that: predicate<Uri>(
-                          (uri) => uri.path.endsWith('config.json'),),),
-              headers: any(named: 'headers'),),).thenAnswer((invocation) async {
+                that: predicate<Uri>(
+                  (uri) => uri.path.endsWith('config.json'),
+                ),
+              ),
+              headers: any(named: 'headers'),
+            ),
+          ).thenAnswer((invocation) async {
             return Response('{}', 200);
           });
         });
@@ -510,6 +531,7 @@ void main() {
         test('Creates Attachment Uri based on config', () {
           const name = 'FileName';
           expect(
+            // ignore: deprecated_member_use_from_same_package
             client.createAttachmentUrl(name).toString(),
             predicate<String>(
               (uriString) =>
@@ -519,148 +541,446 @@ void main() {
         });
 
         group('Upload Data', () {
-          final attachment = Attachment(name: 'name', url: Uri(
-            path: 'with/elements',
-          ), type: 'type',);
-          final action = FormAction('actionUri', 'POST');
-          final bytes = Uint8List(10);
-          final attachmentAction =
-              AddAttachmentAction(byteData: bytes, attachment: attachment);
-          final formData = FormData(
-            title: 'Title',
-            components: [
-              AttachmentFormComponent(
-                property: 'property',
-                data: AttachmentDataEntity([attachment]),
-                fieldId: 'fieldId',
+          group('Generic Files', () {
+            final attachment = Attachment(
+              name: 'name',
+              url: Uri(
+                path: 'with/elements',
               ),
-            ],
-            schema: null,
-            actions: [action],
-            attachmentActions: {attachment: attachmentAction},
-          );
-
-          test('Getting Upload Url fails', () async {
-            final response = Response('body', 400);
-            final baseUri = Uri.parse(
-              attachmentConfig[ApptiveGridEnvironment.production]!
-                  .signedUrlApiEndpoint,
+              type: 'type',
             );
-            when(() => httpClient.get(any(that: predicate<Uri>((requestUri) {
-              return baseUri.scheme == requestUri.scheme &&
-                  baseUri.host == requestUri.host &&
-                  baseUri.path == requestUri.path &&
-              requestUri.queryParameters['fileType'] == attachmentAction.attachment.type &&
-              requestUri.queryParameters['fileName'] != null;
-            }),), headers: any(named: 'headers'),),)
-                .thenAnswer((_) async {
-                  return response;
+            final action = FormAction('actionUri', 'POST');
+            final bytes = Uint8List(10);
+            final attachmentAction =
+                AddAttachmentAction(byteData: bytes, attachment: attachment);
+            final formData = FormData(
+              title: 'Title',
+              components: [
+                AttachmentFormComponent(
+                  property: 'property',
+                  data: AttachmentDataEntity([attachment]),
+                  fieldId: 'fieldId',
+                ),
+              ],
+              schema: null,
+              actions: [action],
+              attachmentActions: {attachment: attachmentAction},
+            );
+
+            test('Getting Upload Url fails', () async {
+              final response = Response('body', 400);
+              final baseUri = Uri.parse(
+                attachmentConfig[ApptiveGridEnvironment.production]!
+                    .signedUrlApiEndpoint,
+              );
+              when(
+                () => httpClient.get(
+                  any(
+                    that: predicate<Uri>((requestUri) {
+                      return baseUri.scheme == requestUri.scheme &&
+                          baseUri.host == requestUri.host &&
+                          baseUri.path == requestUri.path &&
+                          requestUri.queryParameters['fileType'] ==
+                              attachmentAction.attachment.type &&
+                          requestUri.queryParameters['fileName'] != null;
+                    }),
+                  ),
+                  headers: any(named: 'headers'),
+                ),
+              ).thenAnswer((_) async {
+                return response;
+              });
+
+              expect(
+                () async => await client.performAction(action, formData),
+                throwsA(equals(response)),
+              );
+            });
+
+            test('Upload Bytes success', () async {
+              final uploadUri = Uri.parse('uploadUrl.com/data');
+              final getResponse =
+                  Response('{"uploadURL":"${uploadUri.toString()}"}', 200);
+              final putResponse = Response('Success', 200);
+              final baseUri = Uri.parse(
+                attachmentConfig[ApptiveGridEnvironment.production]!
+                    .signedUrlApiEndpoint,
+              );
+              when(
+                () => httpClient.get(
+                  any(
+                    that: predicate<Uri>((requestUri) {
+                      return baseUri.scheme == requestUri.scheme &&
+                          baseUri.host == requestUri.host &&
+                          baseUri.path == requestUri.path &&
+                          requestUri.queryParameters['fileType'] ==
+                              attachmentAction.attachment.type &&
+                          requestUri.queryParameters['fileName'] != null;
+                    }),
+                  ),
+                  headers: any(named: 'headers'),
+                ),
+              ).thenAnswer((_) async => getResponse);
+              when(
+                () => httpClient.put(
+                  uploadUri,
+                  headers: any(named: 'headers'),
+                  body: bytes,
+                  encoding: any(named: 'encoding'),
+                ),
+              ).thenAnswer((_) async => putResponse);
+              when(() => httpClient.send(any())).thenAnswer(
+                (realInvocation) async =>
+                    StreamedResponse(Stream.value([]), 200),
+              );
+
+              await client.performAction(action, formData);
+
+              verify(
+                () => httpClient.get(
+                  any(
+                    that: predicate<Uri>((requestUri) {
+                      return baseUri.scheme == requestUri.scheme &&
+                          baseUri.host == requestUri.host &&
+                          baseUri.path == requestUri.path &&
+                          requestUri.queryParameters['fileType'] ==
+                              attachmentAction.attachment.type &&
+                          requestUri.queryParameters['fileName'] != null;
+                    }),
+                  ),
+                  headers: any(named: 'headers'),
+                ),
+              ).called(1);
+              verify(
+                () => httpClient.put(
+                  uploadUri,
+                  headers: any(named: 'headers'),
+                  body: bytes,
+                  encoding: any(named: 'encoding'),
+                ),
+              ).called(1);
+              verify(() => httpClient.send(any())).called(1);
+            });
+
+            test('Upload Fails throws Response', () async {
+              final uploadUri = Uri.parse('uploadUrl.com/data');
+              final getResponse =
+                  Response('{"uploadURL":"${uploadUri.toString()}"}', 200);
+              final putResponse = Response('Error', 500);
+              final baseUri = Uri.parse(
+                attachmentConfig[ApptiveGridEnvironment.production]!
+                    .signedUrlApiEndpoint,
+              );
+              when(
+                () => httpClient.get(
+                  any(
+                    that: predicate<Uri>((requestUri) {
+                      return baseUri.scheme == requestUri.scheme &&
+                          baseUri.host == requestUri.host &&
+                          baseUri.path == requestUri.path &&
+                          requestUri.queryParameters['fileType'] ==
+                              attachmentAction.attachment.type &&
+                          requestUri.queryParameters['fileName'] != null;
+                    }),
+                  ),
+                  headers: any(named: 'headers'),
+                ),
+              ).thenAnswer((_) async => getResponse);
+              when(
+                () => httpClient.put(
+                  uploadUri,
+                  headers: any(named: 'headers'),
+                  body: bytes,
+                  encoding: any(named: 'encoding'),
+                ),
+              ).thenAnswer((_) async => putResponse);
+
+              await expectLater(
+                () async => await client.performAction(action, formData),
+                throwsA(equals(putResponse)),
+              );
+
+              verify(
+                () => httpClient.get(
+                  any(
+                    that: predicate<Uri>((requestUri) {
+                      return baseUri.scheme == requestUri.scheme &&
+                          baseUri.host == requestUri.host &&
+                          baseUri.path == requestUri.path &&
+                          requestUri.queryParameters['fileType'] ==
+                              attachmentAction.attachment.type &&
+                          requestUri.queryParameters['fileName'] != null;
+                    }),
+                  ),
+                  headers: any(named: 'headers'),
+                ),
+              ).called(1);
+              verify(
+                () => httpClient.put(
+                  uploadUri,
+                  headers: any(named: 'headers'),
+                  body: bytes,
+                  encoding: any(named: 'encoding'),
+                ),
+              ).called(1);
+              verifyNever(() => httpClient.send(any()));
+            });
+
+            group('Images', () {
+              final attachment = Attachment(
+                name: 'name',
+                url: Uri(
+                  path: 'main',
+                ),
+                smallThumbnail: Uri(
+                  path: 'small',
+                ),
+                largeThumbnail: Uri(
+                  path: 'large',
+                ),
+                type: 'image/png',
+              );
+              final action = FormAction('actionUri', 'POST');
+              final bytes = Uint8List(10);
+              final attachmentAction =
+                  AddAttachmentAction(byteData: bytes, attachment: attachment);
+              final formData = FormData(
+                title: 'Title',
+                components: [
+                  AttachmentFormComponent(
+                    property: 'property',
+                    data: AttachmentDataEntity([attachment]),
+                    fieldId: 'fieldId',
+                  ),
+                ],
+                schema: null,
+                actions: [action],
+                attachmentActions: {attachment: attachmentAction},
+              );
+
+              test('Thumbnails are uploaded', () async {
+                final uploadUri = Uri.parse('uploadUrl.com/data');
+                final getResponse =
+                    Response('{"uploadURL":"${uploadUri.toString()}"}', 200);
+                final putResponse = Response('Success', 200);
+                final baseUri = Uri.parse(
+                  attachmentConfig[ApptiveGridEnvironment.production]!
+                      .signedUrlApiEndpoint,
+                );
+                when(
+                  () => httpClient.get(
+                    any(
+                      that: predicate<Uri>((requestUri) {
+                        return baseUri.scheme == requestUri.scheme &&
+                            baseUri.host == requestUri.host &&
+                            baseUri.path == requestUri.path &&
+                            requestUri.queryParameters['fileType'] ==
+                                attachmentAction.attachment.type &&
+                            requestUri.queryParameters['fileName'] != null;
+                      }),
+                    ),
+                    headers: any(named: 'headers'),
+                  ),
+                ).thenAnswer((_) async => getResponse);
+                when(
+                  () => httpClient.put(
+                    uploadUri,
+                    headers: any(named: 'headers'),
+                    body: bytes,
+                    encoding: any(named: 'encoding'),
+                  ),
+                ).thenAnswer((_) async => putResponse);
+                when(() => httpClient.send(any())).thenAnswer(
+                  (realInvocation) async =>
+                      StreamedResponse(Stream.value([]), 200),
+                );
+
+                await client.performAction(action, formData);
+
+                verify(
+                  () => httpClient.get(
+                    any(
+                      that: predicate<Uri>((requestUri) {
+                        return baseUri.scheme == requestUri.scheme &&
+                            baseUri.host == requestUri.host &&
+                            baseUri.path == requestUri.path &&
+                            requestUri.queryParameters['fileType'] ==
+                                attachmentAction.attachment.type &&
+                            requestUri.queryParameters['fileName'] != null;
+                      }),
+                    ),
+                    headers: any(named: 'headers'),
+                  ),
+                ).called(3);
+                verify(
+                  () => httpClient.put(
+                    uploadUri,
+                    headers: any(named: 'headers'),
+                    body: bytes,
+                    encoding: any(named: 'encoding'),
+                  ),
+                ).called(3);
+                verify(() => httpClient.send(any())).called(1);
+              });
+
+              test('Thumbnail upload fails, main upload succeed, call succeeds',
+                  () async {
+                final uploadUri = Uri.parse('https://uploadUrl.com/data');
+                final putSuccess = Response('Success', 200);
+                final putFail = Response('Fail', 400);
+                final baseUri = Uri.parse(
+                  attachmentConfig[ApptiveGridEnvironment.production]!
+                      .signedUrlApiEndpoint,
+                );
+                when(
+                  () => httpClient.get(
+                    any(
+                      that: predicate<Uri>((requestUri) {
+                        return baseUri.scheme == requestUri.scheme &&
+                            baseUri.host == requestUri.host &&
+                            baseUri.path == requestUri.path &&
+                            requestUri.queryParameters['fileType'] ==
+                                attachmentAction.attachment.type &&
+                            requestUri.queryParameters['fileName'] != null;
+                      }),
+                    ),
+                    headers: any(named: 'headers'),
+                  ),
+                ).thenAnswer((invocation) async {
+                  final requestUri = uploadUri.replace(
+                    pathSegments: [
+                      (invocation.positionalArguments.first as Uri)
+                          .queryParameters['fileName']!
+                    ],
+                  );
+                  // Use filename in upload uri to match error responses
+                  return Response(
+                    '{"uploadURL":"${requestUri.toString()}"}',
+                    200,
+                  );
                 });
+                when(
+                  () => httpClient.put(
+                    any(
+                      that: predicate<Uri>(
+                        (uri) => uri.host == uploadUri.host,
+                      ),
+                    ),
+                    headers: any(named: 'headers'),
+                    body: bytes,
+                    encoding: any(named: 'encoding'),
+                  ),
+                ).thenAnswer((invocation) async {
+                  final uri = invocation.positionalArguments.first as Uri;
+                  if (uri.pathSegments.last == 'main') {
+                    return putSuccess;
+                  } else {
+                    return putFail;
+                  }
+                });
+                when(() => httpClient.send(any())).thenAnswer(
+                  (realInvocation) async =>
+                      StreamedResponse(Stream.value([]), 200),
+                );
 
-            expect(
-              () async => await client.performAction(action, formData),
-              throwsA(equals(response)),
-            );
-          });
+                await client.performAction(action, formData);
 
-          test('Upload Bytes success', () async {
-            final uploadUri = Uri.parse('uploadUrl.com/data');
-            final getResponse =
-                Response('{"uploadURL":"${uploadUri.toString()}"}', 200);
-            final putResponse = Response('Success', 200);
-            final baseUri = Uri.parse(
-              attachmentConfig[ApptiveGridEnvironment.production]!
-                  .signedUrlApiEndpoint,
-            );
-            when(() => httpClient.get(any(that: predicate<Uri>((requestUri) {
-              return baseUri.scheme == requestUri.scheme &&
-                  baseUri.host == requestUri.host &&
-                  baseUri.path == requestUri.path &&
-                  requestUri.queryParameters['fileType'] == attachmentAction.attachment.type &&
-                  requestUri.queryParameters['fileName'] != null;
-            }),), headers: any(named: 'headers'),),)
-                .thenAnswer((_) async => getResponse);
-            when(
-              () => httpClient.put(
-                uploadUri,
-                headers: any(named: 'headers'),
-                body: bytes,
-                encoding: any(named: 'encoding'),
-              ),
-            ).thenAnswer((_) async => putResponse);
-            when(() => httpClient.send(any())).thenAnswer(
-              (realInvocation) async => StreamedResponse(Stream.value([]), 200),
-            );
+                verify(
+                  () => httpClient.get(
+                    any(
+                      that: predicate<Uri>((requestUri) {
+                        return baseUri.scheme == requestUri.scheme &&
+                            baseUri.host == requestUri.host &&
+                            baseUri.path == requestUri.path &&
+                            requestUri.queryParameters['fileType'] ==
+                                attachmentAction.attachment.type &&
+                            requestUri.queryParameters['fileName'] != null;
+                      }),
+                    ),
+                    headers: any(named: 'headers'),
+                  ),
+                ).called(3);
+                verify(
+                  () => httpClient.put(
+                    any(
+                      that: predicate<Uri>(
+                        (uri) => uri.host == uploadUri.host,
+                      ),
+                    ),
+                    headers: any(named: 'headers'),
+                    body: bytes,
+                    encoding: any(named: 'encoding'),
+                  ),
+                ).called(3);
+                verify(() => httpClient.send(any())).called(1);
+              });
 
-            await client.performAction(action, formData);
+              test('Main upload fails, thumbnails succeed, call fails',
+                  () async {
+                final uploadUri = Uri.parse('https://uploadUrl.com/data');
+                final putSuccess = Response('Success', 200);
+                final putFail = Response('Fail', 400);
+                final baseUri = Uri.parse(
+                  attachmentConfig[ApptiveGridEnvironment.production]!
+                      .signedUrlApiEndpoint,
+                );
+                when(
+                  () => httpClient.get(
+                    any(
+                      that: predicate<Uri>((requestUri) {
+                        return baseUri.scheme == requestUri.scheme &&
+                            baseUri.host == requestUri.host &&
+                            baseUri.path == requestUri.path &&
+                            requestUri.queryParameters['fileType'] ==
+                                attachmentAction.attachment.type &&
+                            requestUri.queryParameters['fileName'] != null;
+                      }),
+                    ),
+                    headers: any(named: 'headers'),
+                  ),
+                ).thenAnswer((invocation) async {
+                  final requestUri = uploadUri.replace(
+                    pathSegments: [
+                      (invocation.positionalArguments.first as Uri)
+                          .queryParameters['fileName']!
+                    ],
+                  );
+                  // Use filename in upload uri to match error responses
+                  return Response(
+                    '{"uploadURL":"${requestUri.toString()}"}',
+                    200,
+                  );
+                });
+                when(
+                  () => httpClient.put(
+                    any(
+                      that: predicate<Uri>(
+                        (uri) => uri.host == uploadUri.host,
+                      ),
+                    ),
+                    headers: any(named: 'headers'),
+                    body: bytes,
+                    encoding: any(named: 'encoding'),
+                  ),
+                ).thenAnswer((invocation) async {
+                  final uri = invocation.positionalArguments.first as Uri;
+                  if (uri.pathSegments.last == 'main') {
+                    return putFail;
+                  } else {
+                    return putSuccess;
+                  }
+                });
+                when(() => httpClient.send(any())).thenAnswer(
+                  (realInvocation) async =>
+                      StreamedResponse(Stream.value([]), 200),
+                );
 
-            verify(() => httpClient.get(any(that: predicate<Uri>((requestUri) {
-              return baseUri.scheme == requestUri.scheme &&
-                  baseUri.host == requestUri.host &&
-                  baseUri.path == requestUri.path &&
-                  requestUri.queryParameters['fileType'] == attachmentAction.attachment.type &&
-                  requestUri.queryParameters['fileName'] != null;
-            }),), headers: any(named: 'headers'),),)
-                .called(1);
-            verify(
-              () => httpClient.put(
-                uploadUri,
-                headers: any(named: 'headers'),
-                body: bytes,
-                encoding: any(named: 'encoding'),
-              ),
-            ).called(1);
-            verify(() => httpClient.send(any())).called(1);
-          });
-
-          test('Upload Fails throws Response', () async {
-            final uploadUri = Uri.parse('uploadUrl.com/data');
-            final getResponse =
-                Response('{"uploadURL":"${uploadUri.toString()}"}', 200);
-            final putResponse = Response('Error', 500);
-            final baseUri = Uri.parse(
-              attachmentConfig[ApptiveGridEnvironment.production]!
-                  .signedUrlApiEndpoint,
-            );
-            when(() => httpClient.get(any(that: predicate<Uri>((requestUri) {
-              return baseUri.scheme == requestUri.scheme &&
-                  baseUri.host == requestUri.host &&
-                  baseUri.path == requestUri.path &&
-                  requestUri.queryParameters['fileType'] == attachmentAction.attachment.type &&
-                  requestUri.queryParameters['fileName'] != null;
-            }),), headers: any(named: 'headers'),),)
-                .thenAnswer((_) async => getResponse);
-            when(
-              () => httpClient.put(
-                uploadUri,
-                headers: any(named: 'headers'),
-                body: bytes,
-                encoding: any(named: 'encoding'),
-              ),
-            ).thenAnswer((_) async => putResponse);
-
-            await expectLater(
-              () async => await client.performAction(action, formData),
-              throwsA(equals(putResponse)),
-            );
-
-            verify(() => httpClient.get(any(that: predicate<Uri>((requestUri) {
-              return baseUri.scheme == requestUri.scheme &&
-                  baseUri.host == requestUri.host &&
-                  baseUri.path == requestUri.path &&
-                  requestUri.queryParameters['fileType'] == attachmentAction.attachment.type &&
-                  requestUri.queryParameters['fileName'] != null;
-            }),), headers: any(named: 'headers'),),)
-                .called(1);
-            verify(
-              () => httpClient.put(
-                uploadUri,
-                headers: any(named: 'headers'),
-                body: bytes,
-                encoding: any(named: 'encoding'),
-              ),
-            ).called(1);
-            verifyNever(() => httpClient.send(any()));
+                expect(
+                  () => client.performAction(action, formData),
+                  throwsA(isInstanceOf<Response>()),
+                );
+              });
+            });
           });
         });
 
@@ -791,17 +1111,26 @@ void main() {
             ),
             authenticator: authenticator,
           );
-          when(() => httpClient.get(
-            any(
-              that: predicate<Uri>(
-                    (uri) => uri.path.endsWith('config.json'),),),
-            headers: any(named: 'headers'),),).thenAnswer((invocation) async {
+          when(
+            () => httpClient.get(
+              any(
+                that: predicate<Uri>(
+                  (uri) => uri.path.endsWith('config.json'),
+                ),
+              ),
+              headers: any(named: 'headers'),
+            ),
+          ).thenAnswer((invocation) async {
             return Response('{}', 200);
           });
         });
 
         group('Upload Data', () {
-          final attachment = Attachment(name: 'name', url: Uri(path: 'with/path'), type: 'type');
+          final attachment = Attachment(
+            name: 'name',
+            url: Uri(path: 'with/path'),
+            type: 'type',
+          );
           final action = FormAction('actionUri', 'POST');
           final bytes = Uint8List(10);
           final attachmentAction =
@@ -821,7 +1150,8 @@ void main() {
           );
 
           test('Creates upload Url without headers', () async {
-            when(() => authenticator.isAuthenticated).thenAnswer((_) async => false);
+            when(() => authenticator.isAuthenticated)
+                .thenAnswer((_) async => false);
             final uploadUri = Uri.parse('uploadUrl.com/data');
             final getResponse =
                 Response('{"uploadURL":"${uploadUri.toString()}"}', 200);
@@ -830,14 +1160,21 @@ void main() {
               attachmentConfig[ApptiveGridEnvironment.production]!
                   .signedUrlFormApiEndpoint!,
             );
-            when(() => httpClient.get(any(that: predicate<Uri>((requestUri) {
-              return baseUri.scheme == requestUri.scheme &&
-                  baseUri.host == requestUri.host &&
-                  baseUri.path == requestUri.path &&
-                  requestUri.queryParameters['fileType'] == attachmentAction.attachment.type &&
-                  requestUri.queryParameters['fileName'] != null;
-            }),), headers: any(named: 'headers')))
-                .thenAnswer((_) async => getResponse);
+            when(
+              () => httpClient.get(
+                any(
+                  that: predicate<Uri>((requestUri) {
+                    return baseUri.scheme == requestUri.scheme &&
+                        baseUri.host == requestUri.host &&
+                        baseUri.path == requestUri.path &&
+                        requestUri.queryParameters['fileType'] ==
+                            attachmentAction.attachment.type &&
+                        requestUri.queryParameters['fileName'] != null;
+                  }),
+                ),
+                headers: any(named: 'headers'),
+              ),
+            ).thenAnswer((_) async => getResponse);
             when(
               () => httpClient.put(
                 uploadUri,

--- a/packages/apptive_grid_core/test/attachment_processor_test.dart
+++ b/packages/apptive_grid_core/test/attachment_processor_test.dart
@@ -1,0 +1,191 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:apptive_grid_core/apptive_grid_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:image/image.dart' as img;
+import 'package:mocktail/mocktail.dart';
+
+import 'mocks.dart';
+
+void main() {
+  const signedUrl = 'https://signed.url';
+  const signedFormUrl = 'https://signed.form/url';
+  final attachmentUrl = Uri.parse('https://attachment.url');
+
+  late AttachmentProcessor processor;
+  late http.Client httpClient;
+  late ApptiveGridAuthenticator authenticator;
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
+  });
+
+  setUp(() {
+    httpClient = MockHttpClient();
+    authenticator = MockApptiveGridAuthenticator();
+    processor = AttachmentProcessor(
+      const ApptiveGridOptions(),
+      authenticator,
+      httpClient: httpClient,
+    );
+
+    when(
+      () => httpClient.get(
+        any(
+          that: predicate<Uri>(
+            (uri) => uri.path.endsWith('config.json'),
+          ),
+        ),
+        headers: any(named: 'headers'),
+      ),
+    ).thenAnswer((invocation) async {
+      return http.Response(
+        jsonEncode({
+          'attachments': {
+            "unauthenticatedSignedUrlEndpoint": signedFormUrl,
+            "signedUrlEndpoint": signedUrl,
+            "apiEndpoint": attachmentUrl.toString(),
+          }
+        }),
+        200,
+      );
+    });
+  });
+  group('Create Attachment', () {
+    final uuidRegex = RegExp(
+      r'^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$',
+      caseSensitive: false,
+    );
+
+    test('Image generates thumbnailUrls', () async {
+      final attachment = await processor.createAttachment('attachment.png');
+
+      expect(attachment.type, equals('image/png'));
+      expect(attachment.name, equals('attachment.png'));
+
+      expect(
+        attachment.url,
+        predicate<Uri>(
+          (uri) =>
+              uri.scheme == attachmentUrl.scheme &&
+              uri.host == attachmentUrl.host &&
+              uuidRegex.hasMatch(uri.pathSegments.last),
+        ),
+      );
+
+      expect(
+        attachment.smallThumbnail,
+        predicate<Uri>(
+          (uri) =>
+              uri.scheme == attachmentUrl.scheme &&
+              uri.host == attachmentUrl.host &&
+              uuidRegex.hasMatch(uri.pathSegments.last),
+        ),
+      );
+
+      expect(
+        attachment.largeThumbnail,
+        predicate<Uri>(
+          (uri) =>
+              uri.scheme == attachmentUrl.scheme &&
+              uri.host == attachmentUrl.host &&
+              uuidRegex.hasMatch(uri.pathSegments.last),
+        ),
+      );
+    });
+
+    test('Non image generates no thumbnailUrls', () async {
+      final attachment = await processor.createAttachment('attachment.pdf');
+
+      expect(attachment.type, equals('application/pdf'));
+      expect(attachment.name, equals('attachment.pdf'));
+
+      expect(
+        attachment.url,
+        predicate<Uri>(
+          (uri) =>
+              uri.scheme == attachmentUrl.scheme &&
+              uri.host == attachmentUrl.host &&
+              uuidRegex.hasMatch(uri.pathSegments.last),
+        ),
+      );
+
+      expect(
+        attachment.smallThumbnail,
+        isNull,
+      );
+
+      expect(
+        attachment.largeThumbnail,
+        isNull,
+      );
+    });
+  });
+
+  group('Scale Image', () {
+    test('No Image, Returns original bytes', () {
+      final bytes = Uint8List(10);
+
+      expect(
+        processor.scaleImageToMaxSize(
+          originalImage: bytes,
+          size: 10,
+          type: 'image/png',
+        ),
+        equals(bytes),
+      );
+    });
+
+    test('Image small enough does not scale', () {
+      // 2x4 Image from https://png-pixel.com/#:~:text=So%20a%20base64%20encoded%201x1%20PNG%20pixel%20wastes%2028%20bytes.
+      final originalImage = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAIAAAAECAYAAACk7+45AAAAEklEQVR42mP8z/C/ngEIGHEzAMiQCfmnp5u6AAAAAElFTkSuQmCC',
+      );
+
+      expect(
+        processor.scaleImageToMaxSize(
+          originalImage: originalImage,
+          size: 4,
+          type: 'image/png',
+        ),
+        equals(originalImage),
+      );
+    });
+
+    test('Scales Portrait Image', () {
+      // 2x4 Image from https://png-pixel.com/#:~:text=So%20a%20base64%20encoded%201x1%20PNG%20pixel%20wastes%2028%20bytes.
+      final originalImage = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAIAAAAECAYAAACk7+45AAAAEklEQVR42mP8z/C/ngEIGHEzAMiQCfmnp5u6AAAAAElFTkSuQmCC',
+      );
+
+      final scaledImage = processor.scaleImageToMaxSize(
+        originalImage: originalImage,
+        size: 2,
+        type: 'image/png',
+      );
+      final image = img.decodeImage(scaledImage)!;
+
+      expect(image.width, equals(1));
+      expect(image.height, equals(2));
+    });
+
+    test('Scales Horizontal Image', () {
+      // 4x2 Image from https://png-pixel.com/#:~:text=So%20a%20base64%20encoded%201x1%20PNG%20pixel%20wastes%2028%20bytes.
+      final originalImage = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAYAAAB/qH1jAAAAE0lEQVR42mP8z/C/ngEJMKILAABzTAT9NQTQfQAAAABJRU5ErkJggg==',
+      );
+
+      final scaledImage = processor.scaleImageToMaxSize(
+        originalImage: originalImage,
+        size: 2,
+        type: 'image/png',
+      );
+      final image = img.decodeImage(scaledImage)!;
+
+      expect(image.width, equals(2));
+      expect(image.height, equals(1));
+    });
+  });
+}

--- a/packages/apptive_grid_form/CHANGELOG.md
+++ b/packages/apptive_grid_form/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.1
+* Use new Attachment System
+
+## 0.9.1-alpha.1
+* Use new Attachment System
+
 ## 0.9.0
 
 ### Breaking Changes

--- a/packages/apptive_grid_form/lib/widgets/form_widget/attachment/add_attachment_button.dart
+++ b/packages/apptive_grid_form/lib/widgets/form_widget/attachment/add_attachment_button.dart
@@ -6,7 +6,6 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:mime/mime.dart';
 import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
 import 'package:provider/provider.dart';
 import 'package:universal_platform/universal_platform.dart';
@@ -122,12 +121,9 @@ class _AddAttachmentButtonState extends State<AddAttachmentButton> {
     if (result != null && result.files.isNotEmpty) {
       final newAttachments = <Attachment>[];
       for (final file in result.files) {
-        final attachment = Attachment(
-          name: file.name,
-          url: ApptiveGrid.getClient(context, listen: false)
-              .createAttachmentUrl(file.name),
-          type: lookupMimeType(file.name) ?? '',
-        );
+        final attachment = await ApptiveGrid.getClient(context, listen: false)
+            .attachmentProcessor
+            .createAttachment(file.name);
         Provider.of<AttachmentManager>(context, listen: false)
             .addAttachment(attachment, file.bytes);
         newAttachments.add(attachment);
@@ -144,12 +140,10 @@ class _AddAttachmentButtonState extends State<AddAttachmentButton> {
     if (result != null && result.isNotEmpty) {
       final newAttachments = <Attachment>[];
       for (final file in result) {
-        final attachment = Attachment(
-          name: file.name,
-          url: ApptiveGrid.getClient(context, listen: false)
-              .createAttachmentUrl(file.name),
-          type: file.mimeType ?? lookupMimeType(file.name) ?? '',
-        );
+        final attachment = await ApptiveGrid.getClient(context, listen: false)
+            .attachmentProcessor
+            .createAttachment(file.name);
+
         final bytes = await file.readAsBytes();
         Provider.of<AttachmentManager>(context, listen: false)
             .addAttachment(attachment, bytes);
@@ -165,12 +159,9 @@ class _AddAttachmentButtonState extends State<AddAttachmentButton> {
     final file = await _imagePicker.pickImage(source: ImageSource.camera);
 
     if (file != null) {
-      final newAttachment = Attachment(
-        name: file.name,
-        url: ApptiveGrid.getClient(context, listen: false)
-            .createAttachmentUrl(file.name),
-        type: file.mimeType ?? lookupMimeType(file.name) ?? '',
-      );
+      final newAttachment = await ApptiveGrid.getClient(context, listen: false)
+          .attachmentProcessor
+          .createAttachment(file.name);
       final bytes = await file.readAsBytes();
       Provider.of<AttachmentManager>(context, listen: false)
           .addAttachment(newAttachment, bytes);

--- a/packages/apptive_grid_form/pubspec.yaml
+++ b/packages/apptive_grid_form/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   intl: ^0.17.0
   linked_scroll_controller: ^0.2.0
   lottie: ^1.2.1
-  mime: ^1.0.1
   permission_handler: ^8.3.0
   permission_handler_platform_interface: ^3.7.0
   provider: ^6.0.2

--- a/packages/apptive_grid_form/pubspec.yaml
+++ b/packages/apptive_grid_form/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_form
 description: A Flutter Package to display ApptiveGrid Forms inside a Flutter App.
-version: 0.9.0-alpha.12
+version: 0.9.1-alpha.1
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_form
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  apptive_grid_core: ^0.9.0
+  apptive_grid_core: ^0.9.3
   file_picker: ^4.3.0
   flutter:
     sdk: flutter

--- a/packages/apptive_grid_form/test/apptive_grid_form_test.dart
+++ b/packages/apptive_grid_form/test/apptive_grid_form_test.dart
@@ -542,7 +542,7 @@ void main() {
     });
 
     testWidgets('No Cache, Error, Shows Error Screen', (tester) async {
-      final client = ApptiveGridClient.fromClient(httpClient);
+      final client = ApptiveGridClient(httpClient: httpClient);
 
       final target = TestApp(
         client: client,
@@ -574,8 +574,8 @@ void main() {
       when(() => cache.getPendingActionItems())
           .thenAnswer((invocation) => cacheMap.toList());
 
-      final client = ApptiveGridClient.fromClient(
-        httpClient,
+      final client = ApptiveGridClient(
+        httpClient: httpClient,
         options: ApptiveGridOptions(
           cache: cache,
         ),

--- a/packages/apptive_grid_form/test/attachment_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/attachment_form_widget_test.dart
@@ -66,8 +66,18 @@ void main() {
             .thenAnswer((_) => Future.value());
         when(() => client.performAction(action, any()))
             .thenAnswer((_) async => Response('body', 200));
-        when(() => client.createAttachmentUrl(filename))
-            .thenReturn(attachmentUri);
+        final attachmentProcessor = MockAttachmentProcessor();
+        when(() => client.attachmentProcessor).thenReturn(attachmentProcessor);
+        when(() => attachmentProcessor.createAttachment(any())).thenAnswer(
+          (invocation) async {
+            final name = invocation.positionalArguments.first;
+            return Attachment(
+              name: name,
+              type: name.endsWith('png') ? 'image/png' : 'application/pdf',
+              url: attachmentUri,
+            );
+          },
+        );
 
         final target = TestApp(
           client: client,
@@ -153,9 +163,19 @@ void main() {
             .thenAnswer((_) => Future.value());
         when(() => client.performAction(action, any()))
             .thenAnswer((_) async => Response('body', 200));
-        when(() => client.createAttachmentUrl(any())).thenAnswer(
-          (invocation) =>
-              Uri.parse('${invocation.positionalArguments.first}.com'),
+        final attachmentProcessor = MockAttachmentProcessor();
+        when(() => client.attachmentProcessor).thenReturn(attachmentProcessor);
+        when(() => attachmentProcessor.createAttachment(any())).thenAnswer(
+          (invocation) async {
+            final name = invocation.positionalArguments.first;
+            return Attachment(
+              name: name,
+              type: name.endsWith('png') ? 'image/png' : 'application/pdf',
+              url: Uri.parse(
+                '$name.com',
+              ),
+            );
+          },
         );
 
         final target = TestApp(
@@ -193,7 +213,6 @@ void main() {
 
       testWidgets('No Attachment from file picker added, completes',
           (tester) async {
-        const filename = 'Filename.png';
         final filePicker = MockFilePicker();
         final attachmentUri = Uri.parse('attachmenturl.com');
         when(
@@ -226,8 +245,18 @@ void main() {
             .thenAnswer((_) => Future.value());
         when(() => client.performAction(action, any()))
             .thenAnswer((_) async => Response('body', 200));
-        when(() => client.createAttachmentUrl(filename))
-            .thenReturn(attachmentUri);
+        final attachmentProcessor = MockAttachmentProcessor();
+        when(() => client.attachmentProcessor).thenReturn(attachmentProcessor);
+        when(() => attachmentProcessor.createAttachment(any())).thenAnswer(
+          (invocation) async {
+            final name = invocation.positionalArguments.first;
+            return Attachment(
+              name: name,
+              type: name.endsWith('png') ? 'image/png' : 'application/pdf',
+              url: attachmentUri,
+            );
+          },
+        );
 
         final target = TestApp(
           client: client,
@@ -311,8 +340,18 @@ void main() {
             .thenAnswer((_) => Future.value());
         when(() => client.performAction(action, any()))
             .thenAnswer((_) async => Response('body', 200));
-        when(() => client.createAttachmentUrl(filename))
-            .thenReturn(attachmentUri);
+        final attachmentProcessor = MockAttachmentProcessor();
+        when(() => client.attachmentProcessor).thenReturn(attachmentProcessor);
+        when(() => attachmentProcessor.createAttachment(any())).thenAnswer(
+          (invocation) async {
+            final name = invocation.positionalArguments.first;
+            return Attachment(
+              name: name,
+              type: name.endsWith('png') ? 'image/png' : 'application/pdf',
+              url: attachmentUri,
+            );
+          },
+        );
 
         final target = TestApp(
           client: client,
@@ -343,7 +382,7 @@ void main() {
         expect(submittedData.components.first.data, equals(data));
       });
 
-      testWidgets('Multiple Attachments from file pickerget added',
+      testWidgets('Multiple Attachments from file picker get added',
           (tester) async {
         const filename1 = 'Filename1.png';
         const filename2 = 'Filename2.pdf';
@@ -400,9 +439,19 @@ void main() {
             .thenAnswer((_) => Future.value());
         when(() => client.performAction(action, any()))
             .thenAnswer((_) async => Response('body', 200));
-        when(() => client.createAttachmentUrl(any())).thenAnswer(
-          (invocation) =>
-              Uri.parse('${invocation.positionalArguments.first}.com'),
+        final attachmentProcessor = MockAttachmentProcessor();
+        when(() => client.attachmentProcessor).thenReturn(attachmentProcessor);
+        when(() => attachmentProcessor.createAttachment(any())).thenAnswer(
+          (invocation) async {
+            final name = invocation.positionalArguments.first;
+            return Attachment(
+              name: name,
+              type: name.endsWith('png') ? 'image/png' : 'application/pdf',
+              url: Uri.parse(
+                '$name.com',
+              ),
+            );
+          },
         );
 
         final target = TestApp(
@@ -505,8 +554,18 @@ void main() {
             .thenAnswer((_) => Future.value());
         when(() => client.performAction(action, any()))
             .thenAnswer((_) async => Response('body', 200));
-        when(() => client.createAttachmentUrl(filename))
-            .thenReturn(attachmentUri);
+        final attachmentProcessor = MockAttachmentProcessor();
+        when(() => client.attachmentProcessor).thenReturn(attachmentProcessor);
+        when(() => attachmentProcessor.createAttachment(any())).thenAnswer(
+          (invocation) async {
+            final name = invocation.positionalArguments.first;
+            return Attachment(
+              name: name,
+              type: name.endsWith('png') ? 'image/png' : 'application/pdf',
+              url: attachmentUri,
+            );
+          },
+        );
 
         final target = TestApp(
           client: client,
@@ -627,8 +686,18 @@ void main() {
       when(() => client.sendPendingActions()).thenAnswer((_) => Future.value());
       when(() => client.performAction(action, any()))
           .thenAnswer((_) async => Response('body', 200));
-      when(() => client.createAttachmentUrl(filename))
-          .thenReturn(attachmentUri);
+      final attachmentProcessor = MockAttachmentProcessor();
+      when(() => client.attachmentProcessor).thenReturn(attachmentProcessor);
+      when(() => attachmentProcessor.createAttachment(any())).thenAnswer(
+        (invocation) async {
+          final name = invocation.positionalArguments.first;
+          return Attachment(
+            name: name,
+            type: name.endsWith('png') ? 'image/png' : 'application/pdf',
+            url: attachmentUri,
+          );
+        },
+      );
 
       final target = TestApp(
         client: client,
@@ -839,8 +908,18 @@ void main() {
       when(() => client.sendPendingActions()).thenAnswer((_) => Future.value());
       when(() => client.performAction(action, any()))
           .thenAnswer((_) async => Response('body', 200));
-      when(() => client.createAttachmentUrl(filename))
-          .thenReturn(attachmentUri);
+      final attachmentProcessor = MockAttachmentProcessor();
+      when(() => client.attachmentProcessor).thenReturn(attachmentProcessor);
+      when(() => attachmentProcessor.createAttachment(any())).thenAnswer(
+        (invocation) async {
+          final name = invocation.positionalArguments.first;
+          return Attachment(
+            name: name,
+            type: name.endsWith('png') ? 'image/png' : 'application/pdf',
+            url: attachmentUri,
+          );
+        },
+      );
 
       final target = TestApp(
         client: client,

--- a/packages/apptive_grid_form/test/common.dart
+++ b/packages/apptive_grid_form/test/common.dart
@@ -16,6 +16,8 @@ class MockHttpClient extends Mock implements http.Client {}
 
 class MockApptiveGridCache extends Mock implements ApptiveGridCache {}
 
+class MockAttachmentProcessor extends Mock implements AttachmentProcessor {}
+
 class MockFilePicker extends Mock
     with MockPlatformInterfaceMixin
     implements FilePicker {}

--- a/packages/apptive_grid_form/test/enum_collection_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/enum_collection_form_widget_test.dart
@@ -146,9 +146,19 @@ void main() {
       when(() => client.sendPendingActions()).thenAnswer((_) => Future.value());
       when(() => client.performAction(action, any()))
           .thenAnswer((_) async => Response('body', 200));
-      when(() => client.createAttachmentUrl(any())).thenAnswer(
-        (invocation) =>
-            Uri.parse('${invocation.positionalArguments.first}.com'),
+      final attachmentProcessor = MockAttachmentProcessor();
+      when(() => client.attachmentProcessor).thenReturn(attachmentProcessor);
+      when(() => attachmentProcessor.createAttachment(any())).thenAnswer(
+        (invocation) async {
+          final name = invocation.positionalArguments.first;
+          return Attachment(
+            name: name,
+            type: name.endsWith('png') ? 'image/png' : 'application/pdf',
+            url: Uri.parse(
+              '$name.com',
+            ),
+          );
+        },
       );
 
       final target = TestApp(


### PR DESCRIPTION
## Rework for attachments

- Deprecated `ApptiveGridClient.fromClient` constructor
    -  Rather provide the arguments in the main constructor
- Deprecate generateUpload Url
    - Hint to how to generate the url through new createAttachment Function
- Handle thumbnail url creation, thumbnail upload, thumbnail scaling for images