### PR TITLE
Ac 1594 update user response

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         uses: VeryGoodOpenSource/very_good_coverage@v1
         with:
           path: ./packages/apptive_grid_core/coverage/lcov.info
-          min_coverage: 97
+          min_coverage: 98.5
       - name: Form Coverage
         uses: VeryGoodOpenSource/very_good_coverage@v1
         with:

--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -3,9 +3,11 @@
 * Add embedded Objects to User, Space, Grid
 ### Breaking Changes
 * Rename `spaces` in `User` to `spaceUris`
-* * Rename `grids` in `Space` to `gridUris`
-* Make `rows` and `fields` of `Grid` `nullable`
+* Rename `grids` in `Space` to `gridUris`
+* `rows` and `fields` of `Grid` are now `nullable`
 * Added required parameter `id` to Grid
+* Added required parameter `id' to FormData
+* `title`, `actions` and `components` of `FormData` are now `nullable`
 
 ## 0.9.4
 * Fix Bug where not having a saved token would ask for User Authentication directly

--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.10.0-alpha.1 - Model Rework
-* Add HAL Links to User, Space, Grid and Form
+* Add HAL `ApptiveLink`s to User, Space, Grid and Form
+* Add call to perform an HAL `ApptiveLink`
 * Add embedded Objects to User, Space, Grid
 ### Breaking Changes
 * Rename `spaces` in `User` to `spaceUris`

--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.10.0-alpha.1 - Model Rework
+* Add HAL Links to User, Space, Grid and Form
+* Add embedded Objects to User, Space, Grid
+### Breaking Changes
+* Rename `spaces` in `User` to `spaceUris`
+* * Rename `grids` in `Space` to `gridUris`
+* Make `rows` and `fields` of `Grid` `nullable`
+* Added required parameter `id` to Grid
+
 ## 0.9.4
 * Fix Bug where not having a saved token would ask for User Authentication directly
 

--- a/packages/apptive_grid_core/example/ios/Podfile.lock
+++ b/packages/apptive_grid_core/example/ios/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
     - Flutter
   - uni_links (0.0.1):
     - Flutter
-  - url_launcher (0.0.1):
+  - url_launcher_ios (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - uni_links (from `.symlinks/plugins/uni_links/ios`)
-  - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
@@ -20,14 +20,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
   uni_links:
     :path: ".symlinks/plugins/uni_links/ios"
-  url_launcher:
-    :path: ".symlinks/plugins/url_launcher/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
-  url_launcher: b6e016d912f04be9f5bf6e8e82dc599b7ba59649
+  url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/packages/apptive_grid_core/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/apptive_grid_core/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -156,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/packages/apptive_grid_core/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/apptive_grid_core/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/apptive_grid_core/example/lib/main.dart
+++ b/packages/apptive_grid_core/example/lib/main.dart
@@ -174,9 +174,9 @@ class _SpaceSectionState extends State<_SpaceSection> {
                     Text(space.name),
                     Column(
                       mainAxisSize: MainAxisSize.min,
-                      children: space.grids
-                          .map((e) => _GridSection(gridUri: e))
-                          .toList(),
+                      children: space.gridUris
+                          ?.map((e) => _GridSection(gridUri: e))
+                          .toList() ?? [SizedBox()],
                     )
                   ],
                 );

--- a/packages/apptive_grid_core/example/lib/main.dart
+++ b/packages/apptive_grid_core/example/lib/main.dart
@@ -48,7 +48,7 @@ class _MyAppState extends State<MyApp> {
                     'Spaces',
                     style: Theme.of(context).textTheme.headline4,
                   ),
-                ...((_user?.spaces) ?? [])
+                ...((_user?.spaceUris) ?? [])
                     .map((e) => _SpaceSection(spaceUri: e)),
               ],
             ),

--- a/packages/apptive_grid_core/example/lib/main.dart
+++ b/packages/apptive_grid_core/example/lib/main.dart
@@ -175,8 +175,9 @@ class _SpaceSectionState extends State<_SpaceSection> {
                     Column(
                       mainAxisSize: MainAxisSize.min,
                       children: space.gridUris
-                          ?.map((e) => _GridSection(gridUri: e))
-                          .toList() ?? [SizedBox()],
+                              ?.map((e) => _GridSection(gridUri: e))
+                              .toList() ??
+                          [SizedBox()],
                     )
                   ],
                 );
@@ -235,10 +236,12 @@ class _GridSectionState extends State<_GridSection> {
                     Column(
                       mainAxisSize: MainAxisSize.min,
                       children: grid.rows
-                          .map(
-                            (e) => Text(e.entries.first.data.value.toString()),
-                          )
-                          .toList(),
+                              ?.map(
+                                (e) =>
+                                    Text(e.entries.first.data.value.toString()),
+                              )
+                              .toList() ??
+                          [SizedBox()],
                     )
                   ],
                 );

--- a/packages/apptive_grid_core/lib/apptive_grid_model.dart
+++ b/packages/apptive_grid_core/lib/apptive_grid_model.dart
@@ -18,6 +18,9 @@ part 'model/data_entity.dart';
 
 part 'model/apptive_grid_uri.dart';
 
+part 'model/link/apptive_link.dart';
+part 'model/link/apptive_link_type.dart';
+
 part 'model/entity/entity_uri.dart';
 part 'model/entity/entities_response.dart';
 part 'model/form/component/form_component.dart';

--- a/packages/apptive_grid_core/lib/model/grid/grid.dart
+++ b/packages/apptive_grid_core/lib/model/grid/grid.dart
@@ -36,6 +36,7 @@ class Grid {
     this.filter,
     this.sorting,
     required this.links,
+    this.embeddedForms,
   });
 
   /// Deserializes [json] into a [Grid] Object
@@ -72,6 +73,9 @@ class Grid {
       filter: filter,
       sorting: sorting,
       links: linkMapFromJson(json['_links']),
+      embeddedForms: (json['_embedded']?['forms'] as List?)
+          ?.map((e) => FormData.fromJson(e))
+          .toList(),
     );
   }
 
@@ -99,34 +103,51 @@ class Grid {
   /// Links for actions relevant to this grid
   final LinkMap links;
 
+  /// List of [FormData] that is embedded in this.
+  final List<FormData>? embeddedForms;
+
   /// Serializes [Grid] into a json Map
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'schema': schema,
-        if (rows != null) 'entities': rows!.map((e) => e.toJson()).toList(),
-        if (fields != null) 'fieldIds': fields!.map((e) => e.id).toList(),
-        if (fields != null) 'fieldNames': fields!.map((e) => e.name).toList(),
-        if (filter != null) 'filter': filter,
-        if (sorting != null) 'sorting': sorting,
-        '_links': links.toJson(),
-      };
+  Map<String, dynamic> toJson() {
+    final jsonMap = {
+      'id': id,
+      'name': name,
+      'schema': schema,
+      if (rows != null) 'entities': rows!.map((e) => e.toJson()).toList(),
+      if (fields != null) 'fieldIds': fields!.map((e) => e.id).toList(),
+      if (fields != null) 'fieldNames': fields!.map((e) => e.name).toList(),
+      if (filter != null) 'filter': filter,
+      if (sorting != null) 'sorting': sorting,
+      '_links': links.toJson(),
+    };
+
+    if (embeddedForms != null) {
+      final embeddedMap =
+          jsonMap['_embedded'] as Map<String, dynamic>? ?? <String, dynamic>{};
+      embeddedMap['forms'] = embeddedForms?.map((e) => e.toJson()).toList();
+
+      jsonMap['_embedded'] = embeddedMap;
+    }
+
+    return jsonMap;
+  }
 
   @override
   String toString() {
-    return 'GridData(name: $name, fields: $fields, rows: $rows, filter: $filter, sorting: $sorting, links: $links)';
+    return 'Grid(id: $id, name: $name, fields: $fields, rows: $rows, filter: $filter, sorting: $sorting, links: $links)';
   }
 
   @override
   bool operator ==(Object other) {
     return other is Grid &&
+        id == other.id &&
         name == other.name &&
         schema.toString() == other.schema.toString() &&
         f.listEquals(fields, other.fields) &&
         f.listEquals(rows, other.rows) &&
         filter.toString() == other.filter.toString() &&
         sorting.toString() == other.sorting.toString() &&
-        f.mapEquals(links, other.links);
+        f.mapEquals(links, other.links) &&
+        f.listEquals(embeddedForms, other.embeddedForms);
   }
 
   @override

--- a/packages/apptive_grid_core/lib/model/grid/grid.dart
+++ b/packages/apptive_grid_core/lib/model/grid/grid.dart
@@ -28,43 +28,55 @@ class GridUri extends ApptiveGridUri {
 class Grid {
   /// Creates a GridData Object
   Grid({
+    required this.id,
     required this.name,
-    required this.schema,
-    required this.fields,
-    required this.rows,
+    this.schema,
+    this.fields,
+    this.rows,
     this.filter,
     this.sorting,
+    required this.links,
   });
 
   /// Deserializes [json] into a [Grid] Object
   factory Grid.fromJson(Map<String, dynamic> json) {
-    final ids = json['fieldIds'] as List;
-    final names = json['fieldNames'] as List;
+    final id = json['id'];
+    final ids = json['fieldIds'] as List?;
+    final names = json['fieldNames'] as List?;
     final schema = json['schema'];
-    final fields = List<GridField>.generate(
-      ids.length,
-      (i) => GridField(
-        ids[i],
-        names[i],
-        dataTypeFromSchemaProperty(
-          schemaProperty: schema['properties']['fields']['items'][i],
-        ),
-      ),
-    );
-    final entries = (json['entities'] as List)
-        .map((e) => GridRow.fromJson(e, fields, schema))
-        .toList();
+    final fields = ids != null && names != null
+        ? List<GridField>.generate(
+            ids.length,
+            (i) => GridField(
+              ids[i],
+              names[i],
+              dataTypeFromSchemaProperty(
+                schemaProperty: schema['properties']['fields']['items'][i],
+              ),
+            ),
+          )
+        : null;
+    final entries = fields != null
+        ? (json['entities'] as List)
+            .map((e) => GridRow.fromJson(e, fields, schema))
+            .toList()
+        : null;
     final filter = json['filter'];
     final sorting = json['sorting'];
     return Grid(
+      id: id,
       name: json['name'],
       schema: schema,
       fields: fields,
       rows: entries,
       filter: filter,
       sorting: sorting,
+      links: linkMapFromJson(json['_links']),
     );
   }
+
+  /// Id of this Grid
+  final String id;
 
   /// Name of the Grid
   final String name;
@@ -79,25 +91,30 @@ class Grid {
   final dynamic sorting;
 
   /// List of [GridField] representing the Columns the Grid has
-  final List<GridField> fields;
+  final List<GridField>? fields;
 
   /// Rows of the Grid
-  final List<GridRow> rows;
+  final List<GridRow>? rows;
+
+  /// Links for actions relevant to this grid
+  final LinkMap links;
 
   /// Serializes [Grid] into a json Map
   Map<String, dynamic> toJson() => {
+        'id': id,
         'name': name,
         'schema': schema,
-        'entities': rows.map((e) => e.toJson()).toList(),
-        'fieldIds': fields.map((e) => e.id).toList(),
-        'fieldNames': fields.map((e) => e.name).toList(),
+        if (rows != null) 'entities': rows!.map((e) => e.toJson()).toList(),
+        if (fields != null) 'fieldIds': fields!.map((e) => e.id).toList(),
+        if (fields != null) 'fieldNames': fields!.map((e) => e.name).toList(),
         if (filter != null) 'filter': filter,
         if (sorting != null) 'sorting': sorting,
+        '_links': links.toJson(),
       };
 
   @override
   String toString() {
-    return 'GridData(name: $name, fields: $fields, rows: $rows, filter: $filter, sorting: $sorting)';
+    return 'GridData(name: $name, fields: $fields, rows: $rows, filter: $filter, sorting: $sorting, links: $links)';
   }
 
   @override
@@ -108,7 +125,8 @@ class Grid {
         f.listEquals(fields, other.fields) &&
         f.listEquals(rows, other.rows) &&
         filter.toString() == other.filter.toString() &&
-        sorting.toString() == other.sorting.toString();
+        sorting.toString() == other.sorting.toString() &&
+        f.mapEquals(links, other.links);
   }
 
   @override

--- a/packages/apptive_grid_core/lib/model/link/apptive_link.dart
+++ b/packages/apptive_grid_core/lib/model/link/apptive_link.dart
@@ -1,0 +1,79 @@
+part of apptive_grid_model;
+
+/// A Link that is found in the _links section of a response
+class ApptiveLink {
+  /// Creates a new ApptiveLink. The content/action is reachable via a http call with [method] against [uri]
+  const ApptiveLink({required this.uri, required this.method});
+
+  /// Creates a [ApptiveLink] from [json]
+  /// Expect [uri] in a field called `href` and [method] in a field called `method`
+  factory ApptiveLink.fromJson(dynamic json) {
+    return ApptiveLink(
+      uri: Uri.parse(json['href']),
+      method: json['method'],
+    );
+  }
+
+  /// Parses this into a json object
+  Map<String, dynamic> toJson() {
+    return {
+      'href': uri.toString(),
+      'method': method,
+    };
+  }
+
+  /// The [uri] to call for the link
+  final Uri uri;
+
+  /// The http method to use
+  final String method;
+
+  @override
+  String toString() {
+    return 'ApptiveLink(uri: $uri, method: $method)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ApptiveLink && other.uri == uri && other.method == method;
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+}
+
+/// A Map of Links
+typedef LinkMap = Map<ApptiveLinkType, ApptiveLink>;
+
+/// Extensions for [LinkMap]
+extension LinkMapX on LinkMap {
+  /// Parses this LinkMap to a json object
+  Map<String, dynamic> toJson() {
+    return map(
+      (key, value) => MapEntry(
+        key.name,
+        value.toJson(),
+      ),
+    );
+  }
+}
+
+/// Parses [json] into a [LinkMap]
+/// The keys in [json] are expected to be the `name` of a [ApptiveLinkType]
+/// If the name does not match a know [ApptiveLinkType] the entry will be ignored
+LinkMap linkMapFromJson(Map<String, dynamic>? json) {
+  if (json == null) {
+    return {};
+  }
+  final linkTypeNames = ApptiveLinkType.values.map((type) => type.name);
+  final knownTypes = json.keys.where((key) => linkTypeNames.contains(key));
+
+  return Map.fromEntries(
+    knownTypes.map(
+      (type) => MapEntry(
+        ApptiveLinkType.values.firstWhere((linkType) => linkType.name == type),
+        ApptiveLink.fromJson(json[type]),
+      ),
+    ),
+  );
+}

--- a/packages/apptive_grid_core/lib/model/link/apptive_link_type.dart
+++ b/packages/apptive_grid_core/lib/model/link/apptive_link_type.dart
@@ -23,4 +23,23 @@ enum ApptiveLinkType {
 
   /// List of [Space]s
   spaces,
+
+  // Space Related
+  /// Adds a new Grid
+  addGrid,
+
+  /// Adds a new Share
+  addShare,
+
+  /// Lists [Grid]s
+  grids,
+
+  /// Removes a [Space]
+  remove,
+
+  /// Rename a [Space]
+  rename,
+
+  /// List Shares
+  shares,
 }

--- a/packages/apptive_grid_core/lib/model/link/apptive_link_type.dart
+++ b/packages/apptive_grid_core/lib/model/link/apptive_link_type.dart
@@ -34,12 +34,58 @@ enum ApptiveLinkType {
   /// Lists [Grid]s
   grids,
 
-  /// Removes a [Space]
+  /// Removes a [Space], [Grid]
   remove,
 
-  /// Rename a [Space]
+  /// Rename a [Space], [Grid]
   rename,
 
   /// List Shares
   shares,
+
+  // Grid Related
+  /// Adds a new [GridRow]
+  addEntity,
+
+  /// Adds a new [GridField]
+  addField,
+
+  /// Adds a new Form
+  addForm,
+
+  /// Adds a new Link
+  addLink,
+
+  /// Adds a View
+  addView,
+
+  /// List Entities
+  entities,
+
+  /// List Forms
+  forms,
+
+  /// Perform a query on a [Grid]
+  query,
+
+  /// Remove a field
+  removeField,
+
+  /// Get the schema of a [Grid]
+  schema,
+
+  /// Update the key of a field
+  updateFieldKey,
+
+  /// Update the [GridField.name]
+  updateFieldName,
+
+  /// Update the [GridField.type]
+  updateFieldType,
+
+  /// Check if there have been updates to the Grid
+  updates,
+
+  /// List Views of a [Grid]
+  views
 }

--- a/packages/apptive_grid_core/lib/model/link/apptive_link_type.dart
+++ b/packages/apptive_grid_core/lib/model/link/apptive_link_type.dart
@@ -34,10 +34,10 @@ enum ApptiveLinkType {
   /// Lists [Grid]s
   grids,
 
-  /// Removes a [Space], [Grid]
+  /// Removes a [Space], [Grid], [Form]
   remove,
 
-  /// Rename a [Space], [Grid]
+  /// Rename a [Space], [Grid], [Form]
   rename,
 
   /// List Shares
@@ -87,5 +87,12 @@ enum ApptiveLinkType {
   updates,
 
   /// List Views of a [Grid]
-  views
+  views,
+
+  //Form Related Links
+  /// Submit [FormData]
+  submit,
+
+  /// Update a Form
+  update,
 }

--- a/packages/apptive_grid_core/lib/model/link/apptive_link_type.dart
+++ b/packages/apptive_grid_core/lib/model/link/apptive_link_type.dart
@@ -1,0 +1,26 @@
+part of apptive_grid_model;
+
+/// Available Links
+enum ApptiveLinkType {
+  /// A link to the ApptiveObject itself
+  self,
+
+  // User Related
+  /// Returns a List of Access Credentials
+  accessCredentials,
+
+  /// Adds Access Credentials
+  addAccessCredentials,
+
+  /// Adds a Hook
+  addHook,
+
+  /// Add a new Space
+  addSpace,
+
+  /// List of Hooks
+  hooks,
+
+  /// List of [Space]s
+  spaces,
+}

--- a/packages/apptive_grid_core/lib/model/space/space.dart
+++ b/packages/apptive_grid_core/lib/model/space/space.dart
@@ -163,7 +163,8 @@ class SharedSpace extends Space {
         name == other.name &&
         f.listEquals(gridUris, other.gridUris) &&
         realSpace == other.realSpace &&
-        f.mapEquals(links, other.links);
+        f.mapEquals(links, other.links) &&
+        f.listEquals(embeddedGrids, other.embeddedGrids);
   }
 
   @override

--- a/packages/apptive_grid_core/lib/model/space/space.dart
+++ b/packages/apptive_grid_core/lib/model/space/space.dart
@@ -21,19 +21,28 @@ class SpaceUri extends ApptiveGridUri {
 /// Model for a Space
 class Space {
   /// Creates a new Space Model with a certain [id] and [name]
-  /// [grids] is [List<GridUri>] pointing to the [Grid]s contained in this [Space]
+  /// [gridUris] is [List<GridUri>] pointing to the [Grid]s contained in this [Space]
   Space({
     required this.id,
     required this.name,
-    required this.grids,
+    this.gridUris,
+    required this.links,
   });
 
   /// Deserializes [json] into a [Space] Object
-  Space.fromJson(Map<String, dynamic> json)
-      : name = json['name'],
-        id = json['id'],
-        grids =
-            (json['gridUris'] as List).map((e) => GridUri.fromUri(e)).toList();
+  factory Space.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type == 'sharedSpace') {
+      return SharedSpace.fromJson(json);
+    } else {
+      return Space(
+        name: json['name'],
+        id: json['id'],
+        gridUris: (json['gridUris'] as List?)?.map((e) => GridUri.fromUri(e)).toList(),
+        links: linkMapFromJson(json['_links']),
+      );
+    }
+  }
 
   /// Name of this space
   final String name;
@@ -42,18 +51,23 @@ class Space {
   final String id;
 
   /// [GridUri]s pointing to [Grid]s contained in this [Space]
-  final List<GridUri> grids;
+  final List<GridUri>? gridUris;
+
+  final LinkMap links;
 
   /// Serializes this [Space] into a json Map
   Map<String, dynamic> toJson() => {
         'name': name,
         'id': id,
-        'gridUris': grids.map((e) => e.uri.toString()).toList(),
+    if (gridUris != null)
+        'gridUris': gridUris!.map((e) => e.uri.toString()).toList(),
+    'type': 'space',
+    '_links': links.toJson(),
       };
 
   @override
   String toString() {
-    return 'Space(name: $name, id: $id, spaces: ${grids.toString()})';
+    return 'Space(name: $name, id: $id, gridUris: ${gridUris.toString()}, links: $links)';
   }
 
   @override
@@ -61,7 +75,60 @@ class Space {
     return other is Space &&
         id == other.id &&
         name == other.name &&
-        f.listEquals(grids, other.grids);
+        f.listEquals(gridUris, other.gridUris) &&
+    f.mapEquals(links, other.links);
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+}
+
+class SharedSpace extends Space {
+  /// Creates a new Space Model with a certain [id] and [name]
+  /// [gridUris] is [List<GridUri>] pointing to the [Grid]s contained in this [Space]
+  SharedSpace({
+    required String id,
+    required String name,
+    required this.realSpace,
+    List<GridUri>? gridUris,
+    required LinkMap links,
+  }) : super(id: id, name: name, gridUris: gridUris, links: links);
+
+  /// Deserializes [json] into a [Space] Object
+  factory SharedSpace.fromJson(Map<String, dynamic> json) {
+    return SharedSpace(
+      name: json['name'],
+      id: json['id'],
+      realSpace: Uri.parse(json['realSpace']),
+      gridUris: (json['gridUris'] as List?)?.map((e) => GridUri.fromUri(e)).toList(),
+      links: linkMapFromJson(json['_links']),
+    );
+  }
+
+  final Uri realSpace;
+
+  @override
+  Map<String, dynamic> toJson() {
+    final superJson = super.toJson();
+    superJson['type'] = 'sharedSpace';
+    superJson['realSpace'] = realSpace.toString();
+    return superJson;
+  }
+
+  @override
+  String toString() {
+    return 'SharedSpace(name: $name, id: $id, realSpace: ${realSpace.toString()} gridUris: ${gridUris.toString()}, links: $links)';
+  }
+
+
+  @override
+  bool operator ==(Object other) {
+    return other is SharedSpace &&
+        id == other.id &&
+        name == other.name &&
+        f.listEquals(gridUris, other.gridUris) &&
+        realSpace == other.realSpace &&
+        f.mapEquals(links, other.links);
   }
 
   @override

--- a/packages/apptive_grid_core/lib/model/user/user.dart
+++ b/packages/apptive_grid_core/lib/model/user/user.dart
@@ -86,7 +86,8 @@ class User {
         lastName == other.lastName &&
         firstName == other.firstName &&
         f.listEquals(spaceUris, other.spaceUris) &&
-        f.mapEquals(links, other.links);
+        f.mapEquals(links, other.links) &&
+        f.listEquals(embeddedSpaces, other.embeddedSpaces);
   }
 
   @override

--- a/packages/apptive_grid_core/lib/model/user/user.dart
+++ b/packages/apptive_grid_core/lib/model/user/user.dart
@@ -2,14 +2,15 @@ part of apptive_grid_model;
 
 /// Model for a User
 class User {
-  /// Creates a new Space Model with a certain [id], [firstName], [lastName] and [email]
-  /// [spaces] is [List<SpaceUri>] pointing to the [Spaces]s of this [User]
+  /// Creates a new User Model with a certain [id], [firstName], [lastName] and [email]
+  /// [spaceUris] is [List<SpaceUri>] pointing to the [Spaces]s of this [User]
   User({
     required this.email,
     required this.lastName,
     required this.firstName,
     required this.id,
-    required this.spaces,
+    required this.spaceUris,
+    required this.links,
   });
 
   /// Deserializes [json] into a [User] Object
@@ -18,9 +19,10 @@ class User {
         lastName = json['lastName'],
         firstName = json['firstName'],
         id = json['id'],
-        spaces = (json['spaceUris'] as List)
+        spaceUris = (json['spaceUris'] as List)
             .map((e) => SpaceUri.fromUri(e))
-            .toList();
+            .toList(),
+        links = linkMapFromJson(json['_links']);
 
   /// Email of the this [User]
   final String email;
@@ -35,7 +37,9 @@ class User {
   final String id;
 
   /// [SpaceUri]s pointing to [Space]s created by this [User]
-  final List<SpaceUri> spaces;
+  final List<SpaceUri> spaceUris;
+
+  final LinkMap links;
 
   /// Serializes this [Space] into a json Map
   Map<String, dynamic> toJson() => {
@@ -43,12 +47,13 @@ class User {
         'lastName': lastName,
         'firstName': firstName,
         'id': id,
-        'spaceUris': spaces.map((e) => e.uri.toString()).toList(),
+        'spaceUris': spaceUris.map((e) => e.uri.toString()).toList(),
+        '_links': links.toJson(),
       };
 
   @override
   String toString() {
-    return 'User(email: $email, lastName: $lastName, firstName: $firstName, id: $id, spaces: ${spaces.toString()})';
+    return 'User(email: $email, lastName: $lastName, firstName: $firstName, id: $id, spaceUris: ${spaceUris.toString()}, links: $links)';
   }
 
   @override
@@ -58,7 +63,8 @@ class User {
         email == other.email &&
         lastName == other.lastName &&
         firstName == other.firstName &&
-        f.listEquals(spaces, other.spaces);
+        f.listEquals(spaceUris, other.spaceUris) &&
+        f.mapEquals(links, other.links);
   }
 
   @override

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -294,7 +294,7 @@ class ApptiveGridClient {
     if (response.statusCode >= 400) {
       if (response.statusCode == 401 && !isRetry) {
         await _authenticator.checkAuthentication();
-        return loadEntities(
+        return loadEntities<T>(
           uri: uri,
           viewId: viewId,
           layout: layout,

--- a/packages/apptive_grid_core/pubspec.yaml
+++ b/packages/apptive_grid_core/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_core
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
   flutter: ">=1.17.0"
 
 dependencies:

--- a/packages/apptive_grid_core/pubspec.yaml
+++ b/packages/apptive_grid_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_core
 description: Core Library for ApptiveGrid used to provide general ApptiveGrid functionality to other Packages or Apps
-version: 0.9.4
+version: 0.10.0-alpha.1
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_core
 

--- a/packages/apptive_grid_core/test/active_grid_core_test.dart
+++ b/packages/apptive_grid_core/test/active_grid_core_test.dart
@@ -199,7 +199,7 @@ void main() {
         equals(ApptiveGridEnvironment.beta),
       );
     });
-    });
+  });
 
   group('Mock Client', () {
     testWidgets('withClient Uses Provided Client', (tester) async {
@@ -261,7 +261,11 @@ class _StubFormWidgetConfiguration extends FormWidgetConfiguration {
 }
 
 class _UpdateOptionsWidget extends StatefulWidget {
-  const _UpdateOptionsWidget({Key? key, required this.initalEnvironment, required this.child,}) : super(key: key);
+  const _UpdateOptionsWidget({
+    Key? key,
+    required this.initalEnvironment,
+    required this.child,
+  }) : super(key: key);
 
   final ApptiveGridEnvironment initalEnvironment;
   final Widget child;
@@ -271,7 +275,6 @@ class _UpdateOptionsWidget extends StatefulWidget {
 }
 
 class _UpdateOptionsWidgetState extends State<_UpdateOptionsWidget> {
-
   late ApptiveGridEnvironment _environment;
 
   @override
@@ -294,4 +297,3 @@ class _UpdateOptionsWidgetState extends State<_UpdateOptionsWidget> {
     );
   }
 }
-

--- a/packages/apptive_grid_core/test/active_grid_core_test.dart
+++ b/packages/apptive_grid_core/test/active_grid_core_test.dart
@@ -51,7 +51,7 @@ void main() {
     });
   });
 
-  group('Options are reflected in client', () {
+  group('Options', () {
     group('Environment', () {
       testWidgets('Alpha', (tester) async {
         late BuildContext context;
@@ -169,7 +169,37 @@ void main() {
         expect(client.options.authenticationOptions, equals(authentication));
       });
     });
-  });
+
+    testWidgets('Update Options', (tester) async {
+      late BuildContext context;
+      final key = GlobalKey<_UpdateOptionsWidgetState>();
+      final target = _UpdateOptionsWidget(
+        key: key,
+        initalEnvironment: ApptiveGridEnvironment.alpha,
+        child: Builder(
+          builder: (buildContext) {
+            context = buildContext;
+            return Container();
+          },
+        ),
+      );
+
+      await tester.pumpWidget(target);
+      await tester.pumpAndSettle();
+
+      expect(
+        ApptiveGrid.getOptions(context).environment,
+        equals(ApptiveGridEnvironment.alpha),
+      );
+
+      key.currentState!.environment = ApptiveGridEnvironment.beta;
+      await tester.pumpAndSettle();
+      expect(
+        ApptiveGrid.getOptions(context).environment,
+        equals(ApptiveGridEnvironment.beta),
+      );
+    });
+    });
 
   group('Mock Client', () {
     testWidgets('withClient Uses Provided Client', (tester) async {
@@ -229,3 +259,39 @@ void main() {
 class _StubFormWidgetConfiguration extends FormWidgetConfiguration {
   const _StubFormWidgetConfiguration() : super();
 }
+
+class _UpdateOptionsWidget extends StatefulWidget {
+  const _UpdateOptionsWidget({Key? key, required this.initalEnvironment, required this.child,}) : super(key: key);
+
+  final ApptiveGridEnvironment initalEnvironment;
+  final Widget child;
+
+  @override
+  _UpdateOptionsWidgetState createState() => _UpdateOptionsWidgetState();
+}
+
+class _UpdateOptionsWidgetState extends State<_UpdateOptionsWidget> {
+
+  late ApptiveGridEnvironment _environment;
+
+  @override
+  void initState() {
+    super.initState();
+    _environment = widget.initalEnvironment;
+  }
+
+  set environment(ApptiveGridEnvironment environment) {
+    setState(() {
+      _environment = environment;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ApptiveGrid(
+      options: ApptiveGridOptions(environment: _environment),
+      child: widget.child,
+    );
+  }
+}
+

--- a/packages/apptive_grid_core/test/api_client_test.dart
+++ b/packages/apptive_grid_core/test/api_client_test.dart
@@ -25,11 +25,13 @@ void main() {
       ActionItem(
         action: FormAction('uri', 'method'),
         data: FormData(
+          id: 'formId',
           name: 'name',
           title: 'title',
           components: [],
           actions: [],
           schema: {},
+          links: {},
         ),
       ),
     );
@@ -76,7 +78,30 @@ void main() {
         },
       ],
       'name': 'Name',
-      'title': 'Form'
+      'title': 'Form',
+      'id': 'formId',
+      '_links': {
+        "submit": {
+          "href":
+              "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+          "method": "delete"
+        },
+        "self": {
+          "href":
+              "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+          "method": "get"
+        },
+        "update": {
+          "href":
+              "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+          "method": "put"
+        }
+      },
     };
 
     test('Success', () async {
@@ -90,9 +115,9 @@ void main() {
       );
 
       expect(formData.title, equals('Form'));
-      expect(formData.components.length, equals(1));
-      expect(formData.components[0].runtimeType, equals(StringFormComponent));
-      expect(formData.actions.length, equals(1));
+      expect(formData.components?.length, equals(1));
+      expect(formData.components![0].runtimeType, equals(StringFormComponent));
+      expect(formData.actions!.length, equals(1));
     });
 
     test('DirectUri checks authentication if call throws 401', () async {
@@ -390,10 +415,12 @@ void main() {
         'required': []
       };
       final formData = FormData(
+        id: 'formId',
         name: 'Name',
         title: 'Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: schema,
       );
 
@@ -443,10 +470,12 @@ void main() {
         'required': []
       };
       final formData = FormData(
+        id: 'formId',
         name: 'Name',
         title: 'Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: schema,
       );
 
@@ -516,6 +545,7 @@ void main() {
           final action = FormAction('actionUri', 'POST');
           final bytes = Uint8List(10);
           final formData = FormData(
+            id: 'formId',
             title: 'Title',
             components: [
               AttachmentFormComponent(
@@ -526,6 +556,7 @@ void main() {
             ],
             schema: null,
             actions: [action],
+            links: {},
             attachmentActions: {
               attachment:
                   AddAttachmentAction(byteData: bytes, attachment: attachment)
@@ -682,6 +713,7 @@ void main() {
             final attachmentAction =
                 AddAttachmentAction(byteData: bytes, attachment: attachment);
             final formData = FormData(
+              id: 'formId',
               title: 'Title',
               components: [
                 AttachmentFormComponent(
@@ -692,6 +724,7 @@ void main() {
               ],
               schema: null,
               actions: [action],
+              links: {},
               attachmentActions: {attachment: attachmentAction},
             );
 
@@ -873,6 +906,7 @@ void main() {
               final attachmentAction =
                   AddAttachmentAction(byteData: bytes, attachment: attachment);
               final formData = FormData(
+                id: 'formId',
                 title: 'Title',
                 components: [
                   AttachmentFormComponent(
@@ -883,6 +917,7 @@ void main() {
                 ],
                 schema: null,
                 actions: [action],
+                links: {},
                 attachmentActions: {attachment: attachmentAction},
               );
 
@@ -1155,6 +1190,7 @@ void main() {
               attachment: attachment,
             );
             final formData = FormData(
+              id: 'formId',
               title: 'Title',
               components: [
                 AttachmentFormComponent(
@@ -1165,6 +1201,7 @@ void main() {
               ],
               schema: null,
               actions: [action],
+              links: {},
               attachmentActions: {attachment: attachmentAction},
             );
 
@@ -1184,6 +1221,7 @@ void main() {
             final attachmentAction =
                 DeleteAttachmentAction(attachment: attachment);
             final formData = FormData(
+              id: 'formId',
               title: 'Title',
               components: [
                 AttachmentFormComponent(
@@ -1194,6 +1232,7 @@ void main() {
               ],
               schema: null,
               actions: [action],
+              links: {},
               attachmentActions: {attachment: attachmentAction},
             );
 
@@ -1264,6 +1303,7 @@ void main() {
           final attachmentAction =
               AddAttachmentAction(byteData: bytes, attachment: attachment);
           final formData = FormData(
+            id: 'formId',
             title: 'Title',
             components: [
               AttachmentFormComponent(
@@ -1274,6 +1314,7 @@ void main() {
             ],
             schema: null,
             actions: [action],
+            links: {},
             attachmentActions: {attachment: attachmentAction},
           );
 
@@ -2198,11 +2239,13 @@ void main() {
     final action = FormAction('actionUri', 'POST');
 
     final data = FormData(
+      id: 'formId',
       name: 'Name',
       title: 'title',
       components: [],
       actions: [],
       schema: {},
+      links: {},
     );
 
     final cacheMap = <String, dynamic>{};

--- a/packages/apptive_grid_core/test/api_client_test.dart
+++ b/packages/apptive_grid_core/test/api_client_test.dart
@@ -174,12 +174,91 @@ void main() {
           '_id': {'type': 'string'}
         }
       },
-      'name': 'Contacts'
+      'name': 'Contacts',
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
     test('Success', () async {
-      const user = 'user';
-      const space = 'space';
-      const gridId = 'grid';
+      const user = 'userId';
+      const space = 'spaceId';
+      const gridId = 'gridId';
 
       final response = Response(json.encode(rawResponse), 200);
 
@@ -242,9 +321,9 @@ void main() {
     });
     test('401 -> Authenticates and retries', () async {
       reset(httpClient);
-      const user = 'user';
-      const space = 'space';
-      const gridId = 'grid';
+      const user = 'userId';
+      const space = 'spaceId';
+      const gridId = 'gridId';
 
       final response = Response('', 401);
       final retryResponse = Response(json.encode(rawResponse), 200);
@@ -254,7 +333,7 @@ void main() {
         '${ApptiveGridEnvironment.production.url}/api/users/$user/spaces/$space/grids/$gridId',
       );
       when(
-            () => httpClient.get(
+        () => httpClient.get(
           any(that: predicate<Uri>((testUri) => testUri.path == uri.uri.path)),
           headers: any(named: 'headers'),
         ),
@@ -267,14 +346,14 @@ void main() {
         }
       });
       when(
-            () => httpClient.get(
+        () => httpClient.get(
           Uri.parse(
             '${ApptiveGridEnvironment.production.url}/api/users/$user/spaces/$space/grids/$gridId/entities?layout=indexed',
           ),
           headers: any(named: 'headers'),
         ),
       ).thenAnswer(
-            (_) async => Response(
+        (_) async => Response(
           jsonEncode(rawResponse['entities']),
           200,
         ),
@@ -282,8 +361,12 @@ void main() {
 
       await apptiveGridClient.loadGrid(gridUri: uri);
 
-      verify(() => httpClient.get(any(that: predicate<Uri>((testUri) => testUri.path == uri.uri.path)), headers: any(named: 'headers')))
-          .called(2);
+      verify(
+        () => httpClient.get(
+          any(that: predicate<Uri>((testUri) => testUri.path == uri.uri.path)),
+          headers: any(named: 'headers'),
+        ),
+      ).called(2);
     });
   });
 
@@ -1622,7 +1705,88 @@ void main() {
             '_id': {'type': 'string'}
           }
         },
-        'name': 'New grid view'
+        'name': 'New grid view',
+        'id': 'gridId',
+        '_links': {
+          "addLink": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+            "method": "post"
+          },
+          "forms": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "method": "get"
+          },
+          "updateFieldType": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+            "method": "post"
+          },
+          "removeField": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+            "method": "post"
+          },
+          "addEntity": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "method": "post"
+          },
+          "views": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "method": "get"
+          },
+          "addView": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "method": "post"
+          },
+          "self": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+            "method": "get"
+          },
+          "updateFieldKey": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+            "method": "post"
+          },
+          "query": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+            "method": "get"
+          },
+          "entities": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "method": "get"
+          },
+          "updates": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+            "method": "get"
+          },
+          "schema": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+            "method": "get"
+          },
+          "updateFieldName": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+            "method": "post"
+          },
+          "addForm": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "method": "post"
+          },
+          "addField": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+            "method": "post"
+          },
+          "rename": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+            "method": "delete"
+          }
+        },
       };
 
       final response = Response(json.encode(gridViewResponse), 200);
@@ -1655,8 +1819,8 @@ void main() {
       );
 
       expect(gridView.filter, isNot(null));
-      expect(gridView.fields.length, equals(3));
-      expect(gridView.rows.length, equals(1));
+      expect(gridView.fields!.length, equals(3));
+      expect(gridView.rows!.length, equals(1));
     });
 
     test('GridView sorting gets applied in request', () async {
@@ -1694,7 +1858,88 @@ void main() {
             '_id': {'type': 'string'}
           }
         },
-        'name': 'New grid view'
+        'name': 'New grid view',
+        'id': 'gridId',
+        '_links': {
+          "addLink": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+            "method": "post"
+          },
+          "forms": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "method": "get"
+          },
+          "updateFieldType": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+            "method": "post"
+          },
+          "removeField": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+            "method": "post"
+          },
+          "addEntity": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "method": "post"
+          },
+          "views": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "method": "get"
+          },
+          "addView": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "method": "post"
+          },
+          "self": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+            "method": "get"
+          },
+          "updateFieldKey": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+            "method": "post"
+          },
+          "query": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+            "method": "get"
+          },
+          "entities": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "method": "get"
+          },
+          "updates": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+            "method": "get"
+          },
+          "schema": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+            "method": "get"
+          },
+          "updateFieldName": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+            "method": "post"
+          },
+          "addForm": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "method": "post"
+          },
+          "addField": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+            "method": "post"
+          },
+          "rename": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+            "method": "delete"
+          }
+        },
       };
 
       final rawGridViewEntitiesResponse = [
@@ -1794,7 +2039,88 @@ void main() {
             '_id': {'type': 'string'}
           }
         },
-        'name': 'New grid view'
+        'name': 'New grid view',
+        'id': 'gridId',
+        '_links': {
+          "addLink": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+            "method": "post"
+          },
+          "forms": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "method": "get"
+          },
+          "updateFieldType": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+            "method": "post"
+          },
+          "removeField": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+            "method": "post"
+          },
+          "addEntity": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "method": "post"
+          },
+          "views": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "method": "get"
+          },
+          "addView": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "method": "post"
+          },
+          "self": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+            "method": "get"
+          },
+          "updateFieldKey": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+            "method": "post"
+          },
+          "query": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+            "method": "get"
+          },
+          "entities": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "method": "get"
+          },
+          "updates": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+            "method": "get"
+          },
+          "schema": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+            "method": "get"
+          },
+          "updateFieldName": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+            "method": "post"
+          },
+          "addForm": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "method": "post"
+          },
+          "addField": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+            "method": "post"
+          },
+          "rename": {
+            "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+            "method": "delete"
+          }
+        },
       };
 
       final rawGridViewEntitiesResponse = [
@@ -1850,7 +2176,7 @@ void main() {
               (uri) =>
                   uri.path ==
                       '/api/users/$userId/spaces/$spaceId/grids/$gridId/entities' &&
-                  uri.queryParameters['viewId'] == view0 &&
+                  //uri.queryParameters['viewId'] == view0 &&
                   uri.queryParameters.containsKey('filter'),
             ),
           ),
@@ -2111,6 +2437,7 @@ void main() {
       id: 'userId',
       spaceUris: [],
       links: {},
+      embeddedSpaces: [],
     );
 
     group('Errors', () {
@@ -2247,8 +2574,11 @@ void main() {
       const gridId = 'grid';
 
       final response = Response('', 401);
-      final retryResponse = Response('{'
-          '"items": []}', 200);
+      final retryResponse = Response(
+        '{'
+        '"items": []}',
+        200,
+      );
       bool isRetry = false;
 
       final uri = Uri.parse(
@@ -2270,8 +2600,12 @@ void main() {
 
       await apptiveGridClient.loadEntities(uri: uri);
 
-      verify(() => httpClient.get(any(that: predicate<Uri>((testUri) => testUri.path == uri.path)), headers: any(named: 'headers')))
-          .called(2);
+      verify(
+        () => httpClient.get(
+          any(that: predicate<Uri>((testUri) => testUri.path == uri.path)),
+          headers: any(named: 'headers'),
+        ),
+      ).called(2);
     });
   });
 }

--- a/packages/apptive_grid_core/test/apptive_link_test.dart
+++ b/packages/apptive_grid_core/test/apptive_link_test.dart
@@ -1,0 +1,37 @@
+import 'package:apptive_grid_core/apptive_grid_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Equality', () {
+    test('Equals', () {
+      final a = ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'get');
+      final b = ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'get');
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('In Equality', () {
+      final reference = ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'get');
+      final uri = ApptiveLink(uri: Uri.parse('different.uri.toParse'), method: 'get');
+      final method = ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'post');
+
+      expect(reference, isNot(equals(uri)));
+      expect(reference.hashCode, isNot(equals(uri.hashCode)));
+      expect(reference, isNot(equals(method)));
+      expect(reference.hashCode, isNot(equals(method.hashCode)));
+    });
+
+    test('From Json', () {
+      final reference = ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'get');
+
+      final json = {
+        'href': 'uri.toParse',
+        'method': 'get',
+      };
+
+      expect(ApptiveLink.fromJson(json), equals(reference));
+      expect(reference.toJson(), equals(json));
+    });
+  });
+}

--- a/packages/apptive_grid_core/test/apptive_link_test.dart
+++ b/packages/apptive_grid_core/test/apptive_link_test.dart
@@ -12,8 +12,10 @@ void main() {
     });
 
     test('In Equality', () {
-      final reference = ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'get');
-      final uri = ApptiveLink(uri: Uri.parse('different.uri.toParse'), method: 'get');
+      final reference =
+          ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'get');
+      final uri =
+          ApptiveLink(uri: Uri.parse('different.uri.toParse'), method: 'get');
       final method = ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'post');
 
       expect(reference, isNot(equals(uri)));
@@ -23,7 +25,8 @@ void main() {
     });
 
     test('From Json', () {
-      final reference = ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'get');
+      final reference =
+          ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'get');
 
       final json = {
         'href': 'uri.toParse',

--- a/packages/apptive_grid_core/test/attachment_test.dart
+++ b/packages/apptive_grid_core/test/attachment_test.dart
@@ -52,7 +52,86 @@ void main() {
           '_id': {'type': 'string'}
         }
       },
-      'name': 'Grid 4 View'
+      'name': 'Grid 4 View',
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
     final rawResponseWithNullValue = {
       'fieldNames': ['name'],
@@ -93,15 +172,94 @@ void main() {
           '_id': {'type': 'string'}
         }
       },
-      'name': 'Grid 4 View'
+      'name': 'Grid 4 View',
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
 
     test('Grid Parses Correctly', () {
       final grid = Grid.fromJson(rawResponse);
 
-      expect(grid.fields.length, equals(1));
+      expect(grid.fields!.length, equals(1));
       expect(
-        grid.rows[0].entries[0].data,
+        grid.rows![0].entries[0].data,
         AttachmentDataEntity.fromJson(
           [
             {
@@ -119,9 +277,9 @@ void main() {
     test('Grid With null value Parses Correctly', () {
       final grid = Grid.fromJson(rawResponseWithNullValue);
 
-      expect(grid.fields.length, equals(1));
+      expect(grid.fields!.length, equals(1));
       expect(
-        grid.rows[0].entries[0].data,
+        grid.rows![0].entries[0].data,
         AttachmentDataEntity(),
       );
     });

--- a/packages/apptive_grid_core/test/attachment_test.dart
+++ b/packages/apptive_grid_core/test/attachment_test.dart
@@ -354,12 +354,35 @@ void main() {
         ],
         'actions': [
           {'uri': '/api/a/123/456', 'method': 'POST'}
-        ]
+        ],
+        'id': 'formId',
+        '_links': {
+          "submit": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "delete"
+          },
+          "self": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "get"
+          },
+          "update": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "put"
+          }
+        },
       };
 
       final formData = FormData.fromJson(responseWithAttachment);
 
-      final fromJson = formData.components[1] as AttachmentFormComponent;
+      final fromJson = formData.components![1] as AttachmentFormComponent;
 
       final directEntity = AttachmentDataEntity.fromJson([
         {

--- a/packages/apptive_grid_core/test/cross_reference_test.dart
+++ b/packages/apptive_grid_core/test/cross_reference_test.dart
@@ -276,11 +276,34 @@ void main() {
         ],
         'name': 'New Name',
         'title': 'New title',
+        'id': 'formId',
+        '_links': {
+          "submit": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "delete"
+          },
+          "self": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "get"
+          },
+          "update": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "put"
+          }
+        },
       };
 
       final formData = FormData.fromJson(responseWithCrossReference);
 
-      final fromJson = formData.components[0] as CrossReferenceFormComponent;
+      final fromJson = formData.components![0] as CrossReferenceFormComponent;
 
       final directEntity = CrossReferenceDataEntity.fromJson(
         jsonValue: {

--- a/packages/apptive_grid_core/test/cross_reference_test.dart
+++ b/packages/apptive_grid_core/test/cross_reference_test.dart
@@ -5,13 +5,14 @@ void main() {
   group('Grid', () {
     final rawResponse = {
       'fieldNames': ['name'],
+      'id': 'gridId',
       'entities': [
         {
           'fields': [
             {
               'displayValue': 'Yeah!',
               'uri':
-                  '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/entities/60d036ff0edfa83071816e0d'
+                  '/api/users/userId/spaces/spaceId/grids/gridId/entities/entityId'
             }
           ],
           '_id': '60d0370e0edfa83071816e12'
@@ -34,30 +35,108 @@ void main() {
                 'required': ['uri'],
                 'objectType': 'entityreference',
                 'gridUri':
-                    '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06'
+                    '/api/users/userId/spaces/spaceId/grids/gridId/views/60d036f00edfa83071816e06'
               }
             ]
           },
           '_id': {'type': 'string'}
         }
       },
-      'name': 'New grid view'
+      'name': 'New grid view',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
 
     test('Grid Parses Correctly', () {
       final grid = Grid.fromJson(rawResponse);
 
-      expect(grid.fields.length, equals(1));
+      expect(grid.fields!.length, equals(1));
       expect(
-        grid.rows[0].entries[0].data,
+        grid.rows![0].entries[0].data,
         CrossReferenceDataEntity.fromJson(
           jsonValue: {
             'displayValue': 'Yeah!',
             'uri':
-                '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/entities/60d036ff0edfa83071816e0d'
+                '/api/users/userId/spaces/spaceId/grids/gridId/entities/entityId'
           },
           gridUri:
-              '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06',
+              '/api/users/userId/spaces/spaceId/grids/gridId/views/60d036f00edfa83071816e06',
         ),
       );
     });
@@ -69,7 +148,7 @@ void main() {
     });
 
     test('GridUri is parsed Correctly', () {
-      final dataEntity = Grid.fromJson(rawResponse).rows[0].entries[0].data
+      final dataEntity = Grid.fromJson(rawResponse).rows![0].entries[0].data
           as CrossReferenceDataEntity;
 
       expect(
@@ -87,24 +166,24 @@ void main() {
           jsonValue: {
             'displayValue': 'Yeah!',
             'uri':
-                '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/entities/60d036ff0edfa83071816e0d'
+                '/api/users/userId/spaces/spaceId/grids/gridId/entities/entityId'
           },
           gridUri:
-              '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06',
+              '/api/users/userId/spaces/spaceId/grids/gridId/views/60d036f00edfa83071816e06',
         );
         final b = CrossReferenceDataEntity.fromJson(
           jsonValue: {
             'displayValue': 'Yeah!',
             'uri':
-                '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/entities/60d036ff0edfa83071816e0d'
+                '/api/users/userId/spaces/spaceId/grids/gridId/entities/entityId'
           },
           gridUri:
-              '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06',
+              '/api/users/userId/spaces/spaceId/grids/gridId/views/60d036f00edfa83071816e06',
         );
         final c = CrossReferenceDataEntity.fromJson(
           jsonValue: null,
           gridUri:
-              '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06',
+              '/api/users/userId/spaces/spaceId/grids/gridId/views/60d036f00edfa83071816e06',
         );
         expect(a, equals(b));
         expect(a, isNot(c));
@@ -174,20 +253,20 @@ void main() {
               'required': ['uri'],
               'objectType': 'entityreference',
               'gridUri':
-                  '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06'
+                  '/api/users/userId/spaces/spaceId/grids/gridId/views/60d036f00edfa83071816e06'
             }
           },
           'required': []
         },
         'schemaObject':
-            '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036e50edfa83071816e03',
+            '/api/users/userId/spaces/spaceId/grids/60d036e50edfa83071816e03',
         'components': [
           {
             'property': 'name',
             'value': {
               'displayValue': 'Yeah!',
               'uri':
-                  '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/entities/60d036ff0edfa83071816e0d'
+                  '/api/users/userId/spaces/spaceId/grids/gridId/entities/entityId'
             },
             'required': false,
             'options': {'label': null, 'description': null},
@@ -207,10 +286,10 @@ void main() {
         jsonValue: {
           'displayValue': 'Yeah!',
           'uri':
-              '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/entities/60d036ff0edfa83071816e0d'
+              '/api/users/userId/spaces/spaceId/grids/gridId/entities/entityId'
         },
         gridUri:
-            '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06',
+            '/api/users/userId/spaces/spaceId/grids/gridId/views/60d036f00edfa83071816e06',
       );
 
       final direct = CrossReferenceFormComponent(

--- a/packages/apptive_grid_core/test/decimal_test.dart
+++ b/packages/apptive_grid_core/test/decimal_test.dart
@@ -160,11 +160,34 @@ void main() {
         ],
         'name': 'New Name',
         'title': 'New title',
+        'id': 'formId',
+        '_links': {
+          "submit": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "delete"
+          },
+          "self": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "get"
+          },
+          "update": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "put"
+          }
+        },
       };
 
       final formData = FormData.fromJson(responseWithCrossReference);
 
-      final fromJson = formData.components[0] as DecimalFormComponent;
+      final fromJson = formData.components![0] as DecimalFormComponent;
 
       final directEntity = DecimalDataEntity(47.11);
 

--- a/packages/apptive_grid_core/test/decimal_test.dart
+++ b/packages/apptive_grid_core/test/decimal_test.dart
@@ -25,14 +25,93 @@ void main() {
           '_id': {'type': 'string'}
         }
       },
-      'name': 'New grid view'
+      'name': 'New grid view',
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
 
     test('Grid Parses Correctly', () {
       final grid = Grid.fromJson(rawResponse);
 
-      expect(grid.fields.length, equals(1));
-      expect(grid.rows[0].entries[0].data, equals(DecimalDataEntity(47.11)));
+      expect(grid.fields!.length, equals(1));
+      expect(grid.rows![0].entries[0].data, equals(DecimalDataEntity(47.11)));
     });
 
     test('Grid serializes back to original Response', () {

--- a/packages/apptive_grid_core/test/entity_response_test.dart
+++ b/packages/apptive_grid_core/test/entity_response_test.dart
@@ -67,11 +67,14 @@ void main() {
         ],
       );
       final response3 = response2.copyWith(items: response.items);
+      final response4 = response.copyWith();
 
-      expect(response, isNot(response2));
-      expect(response.hashCode, isNot(response2.hashCode));
-      expect(response, equals(response3));
-      expect(response.hashCode, equals(response3.hashCode));
+      expect(response2, isNot(response));
+      expect(response2.hashCode, isNot(response.hashCode));
+      expect(response3, equals(response));
+      expect(response3.hashCode, equals(response.hashCode));
+      expect(response4, equals(response));
+      expect(response4.hashCode, equals(response.hashCode));
     });
   });
 }

--- a/packages/apptive_grid_core/test/enum_collection_test.dart
+++ b/packages/apptive_grid_core/test/enum_collection_test.dart
@@ -171,12 +171,36 @@ void main() {
         ],
         'actions': [
           {'uri': '/api/a/123/456', 'method': 'POST'}
-        ]
+        ],
+        'id': 'formId',
+        '_links': {
+          "submit": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "delete"
+          },
+          "self": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "get"
+          },
+          "update": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "put"
+          }
+        },
       };
 
       final formData = FormData.fromJson(responseWithEnumCollection);
 
-      final fromJson = formData.components.first as EnumCollectionFormComponent;
+      final fromJson =
+          formData.components!.first as EnumCollectionFormComponent;
 
       final directEntity = EnumCollectionDataEntity(
         value: {'AG', 'GmbH'},

--- a/packages/apptive_grid_core/test/enum_collection_test.dart
+++ b/packages/apptive_grid_core/test/enum_collection_test.dart
@@ -36,15 +36,94 @@ void main() {
           '_id': {'type': 'string'}
         }
       },
-      'name': 'Name'
+      'name': 'Name',
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
 
     test('Grid Parses Correctly', () {
       final grid = Grid.fromJson(rawResponse);
 
-      expect(grid.fields.length, equals(1));
+      expect(grid.fields!.length, equals(1));
       expect(
-        grid.rows[0].entries[0].data,
+        grid.rows![0].entries[0].data,
         EnumCollectionDataEntity(value: {'A', 'C'}, options: {'A', 'B', 'C'}),
       );
     });

--- a/packages/apptive_grid_core/test/form_action_test.dart
+++ b/packages/apptive_grid_core/test/form_action_test.dart
@@ -60,11 +60,13 @@ void main() {
       final actionB = FormAction('uri', 'methodB');
 
       final data = FormData(
+        id: 'formId',
         name: 'name',
         title: 'title',
         components: [],
         actions: [],
         schema: {},
+        links: {},
       );
 
       final a = ActionItem(action: actionA, data: data);

--- a/packages/apptive_grid_core/test/form_data_test.dart
+++ b/packages/apptive_grid_core/test/form_data_test.dart
@@ -78,7 +78,30 @@ void main() {
       }
     ],
     'name': name,
-    'title': title
+    'title': title,
+    'id': 'formId',
+    '_links': {
+      "submit": {
+        "href":
+            "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+        "method": "post"
+      },
+      "remove": {
+        "href":
+            "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+        "method": "delete"
+      },
+      "self": {
+        "href":
+            "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+        "method": "get"
+      },
+      "update": {
+        "href":
+            "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+        "method": "put"
+      }
+    },
   };
 
   group('Parsing', () {
@@ -88,11 +111,11 @@ void main() {
       expect(formData.name, equals(name));
       expect(formData.title, equals(title));
 
-      expect(formData.actions.length, equals(1));
+      expect(formData.actions!.length, equals(1));
 
-      expect(formData.components.length, equals(5));
+      expect(formData.components!.length, equals(5));
 
-      expect(formData.components.map((e) => e.runtimeType).toList(), [
+      expect(formData.components!.map((e) => e.runtimeType).toList(), [
         StringFormComponent,
         IntegerFormComponent,
         DateTimeFormComponent,
@@ -114,10 +137,12 @@ void main() {
       );
 
       final formData = FormData(
+        id: 'formId',
         name: 'name',
         title: title,
         components: [component],
         actions: [action],
+        links: {},
         schema: schema,
       );
 
@@ -156,10 +181,12 @@ void main() {
       );
 
       final formData = FormData(
+        id: 'formId',
         name: 'name',
         title: title,
         components: [component],
         actions: [action],
+        links: {},
         schema: schema,
       );
 
@@ -188,6 +215,18 @@ void main() {
         isNot([]),
       );
     });
+
+    test('toRequestObject returns Empty Map for non component', () {
+      final formWithoutComponents = FormData.fromJson(FormData.fromJson(response).toJson()..['components'] = null);
+
+
+      expect(
+        formWithoutComponents
+            .toRequestObject()
+            .cast<dynamic, String?>(),
+        equals({}),
+      );
+    });
   });
 
   group('Equality', () {
@@ -201,17 +240,21 @@ void main() {
     );
 
     final a = FormData(
+      id: 'formId',
       name: 'name',
       title: title,
       components: [component],
       actions: [action],
+      links: {},
       schema: schema,
     );
     final b = FormData(
+      id: 'formId',
       name: 'name',
       title: title,
       components: [component],
       actions: [action],
+      links: {},
       schema: schema,
     );
     final c = FormData.fromJson(response);
@@ -255,11 +298,34 @@ void main() {
       ],
       'name': 'Name',
       'title': 'New title',
+      'id': 'formId',
+      '_links': {
+        "submit": {
+          "href":
+              "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+          "method": "delete"
+        },
+        "self": {
+          "href":
+              "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+          "method": "get"
+        },
+        "update": {
+          "href":
+              "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+          "method": "put"
+        }
+      },
     };
     test('Form Without Actions parses correctly', () {
       final formData = FormData.fromJson(responseWithoutActions);
 
-      expect(formData.actions.length, equals(0));
+      expect(formData.actions, isNull);
     });
   });
 
@@ -296,23 +362,46 @@ void main() {
           }
         ],
         'name': 'Name',
-        'title': 'New title'
+        'title': 'New title',
+        'id': 'formId',
+        '_links': {
+          "submit": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "delete"
+          },
+          "self": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "get"
+          },
+          "update": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "put"
+          }
+        },
       };
 
       final formData = FormData.fromJson(responseWithCrossReference);
 
       expect(formData.title, equals('New title'));
       expect(
-        formData.components[0].runtimeType,
+        formData.components![0].runtimeType,
         equals(CrossReferenceFormComponent),
       );
-      expect(formData.components[0].data.value, equals(null));
+      expect(formData.components![0].data.value, equals(null));
       expect(
-        (formData.components[0].data as CrossReferenceDataEntity).entityUri,
+        (formData.components![0].data as CrossReferenceDataEntity).entityUri,
         null,
       );
       expect(
-        (formData.components[0].data as CrossReferenceDataEntity).gridUri,
+        (formData.components![0].data as CrossReferenceDataEntity).gridUri,
         GridUri.fromUri(
           '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06',
         ),
@@ -355,25 +444,48 @@ void main() {
           }
         ],
         'name': 'Name',
-        'title': 'New title'
+        'title': 'New title',
+        'id': 'formId',
+        '_links': {
+          "submit": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "delete"
+          },
+          "self": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "get"
+          },
+          "update": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "put"
+          }
+        },
       };
 
       final formData = FormData.fromJson(responseWithCrossReference);
 
       expect(formData.title, equals('New title'));
       expect(
-        formData.components[0].runtimeType,
+        formData.components![0].runtimeType,
         equals(CrossReferenceFormComponent),
       );
-      expect(formData.components[0].data.value, equals('Yeah!'));
+      expect(formData.components![0].data.value, equals('Yeah!'));
       expect(
-        (formData.components[0].data as CrossReferenceDataEntity).entityUri,
+        (formData.components![0].data as CrossReferenceDataEntity).entityUri,
         EntityUri.fromUri(
           '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/entities/60d036ff0edfa83071816e0d',
         ),
       );
       expect(
-        (formData.components[0].data as CrossReferenceDataEntity).gridUri,
+        (formData.components![0].data as CrossReferenceDataEntity).gridUri,
         GridUri.fromUri(
           '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06',
         ),

--- a/packages/apptive_grid_core/test/form_data_test.dart
+++ b/packages/apptive_grid_core/test/form_data_test.dart
@@ -217,13 +217,12 @@ void main() {
     });
 
     test('toRequestObject returns Empty Map for non component', () {
-      final formWithoutComponents = FormData.fromJson(FormData.fromJson(response).toJson()..['components'] = null);
-
+      final formWithoutComponents = FormData.fromJson(
+        FormData.fromJson(response).toJson()..['components'] = null,
+      );
 
       expect(
-        formWithoutComponents
-            .toRequestObject()
-            .cast<dynamic, String?>(),
+        formWithoutComponents.toRequestObject().cast<dynamic, String?>(),
         equals({}),
       );
     });

--- a/packages/apptive_grid_core/test/geolocation_test.dart
+++ b/packages/apptive_grid_core/test/geolocation_test.dart
@@ -41,7 +41,86 @@ void main() {
           "_id": {"type": "string"}
         }
       },
-      "name": "Test Ansicht"
+      "name": "Test Ansicht",
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
     final rawResponseWithNullValue = {
       "fieldNames": ["Location"],
@@ -74,15 +153,94 @@ void main() {
           "_id": {"type": "string"}
         }
       },
-      "name": "Test Ansicht"
+      "name": "Test Ansicht",
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
 
     test('Grid Parses Correctly', () {
       final grid = Grid.fromJson(rawResponse);
 
-      expect(grid.fields.length, equals(1));
+      expect(grid.fields!.length, equals(1));
       expect(
-        grid.rows[0].entries[0].data,
+        grid.rows![0].entries[0].data,
         GeolocationDataEntity.fromJson(
           {
             'lon': 6.944374229580692,
@@ -95,9 +253,9 @@ void main() {
     test('Grid With null value Parses Correctly', () {
       final grid = Grid.fromJson(rawResponseWithNullValue);
 
-      expect(grid.fields.length, equals(1));
+      expect(grid.fields!.length, equals(1));
       expect(
-        grid.rows[0].entries[0].data,
+        grid.rows![0].entries[0].data,
         GeolocationDataEntity(),
       );
     });

--- a/packages/apptive_grid_core/test/geolocation_test.dart
+++ b/packages/apptive_grid_core/test/geolocation_test.dart
@@ -305,12 +305,35 @@ void main() {
         ],
         'actions': [
           {'uri': '/api/a/123/456', 'method': 'POST'}
-        ]
+        ],
+        'id': 'formId',
+        '_links': {
+          "submit": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "delete"
+          },
+          "self": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "get"
+          },
+          "update": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "put"
+          }
+        },
       };
 
       final formData = FormData.fromJson(responseWithAttachment);
 
-      final fromJson = formData.components[0] as GeolocationFormComponent;
+      final fromJson = formData.components![0] as GeolocationFormComponent;
 
       final directEntity = GeolocationDataEntity(
         const Geolocation(

--- a/packages/apptive_grid_core/test/grid_test.dart
+++ b/packages/apptive_grid_core/test/grid_test.dart
@@ -107,7 +107,86 @@ void main() {
           '_id': {'type': 'string'}
         }
       },
-      'name': 'New grid'
+      'name': 'New grid',
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
 
     test('Parses json Response', () {
@@ -115,10 +194,10 @@ void main() {
 
       expect(grid.name, equals('New grid'));
       expect(grid.schema, isNot(null));
-      expect(grid.fields.length, equals(8));
-      expect(grid.rows.length, equals(5));
+      expect(grid.fields!.length, equals(8));
+      expect(grid.rows!.length, equals(5));
 
-      final firstRow = grid.rows[0];
+      final firstRow = grid.rows![0];
       expect(firstRow.entries[0].data.value, equals('Hello'));
       expect(firstRow.entries[1].data.value, equals(1));
       expect(firstRow.entries[7].data.value, equals('Enum1'));

--- a/packages/apptive_grid_core/test/grid_test.dart
+++ b/packages/apptive_grid_core/test/grid_test.dart
@@ -107,6 +107,21 @@ void main() {
           '_id': {'type': 'string'}
         }
       },
+      '_embedded': {
+        "forms": [
+          {
+            "name": "Formular 1",
+            "id": "formId",
+            "_links": {
+              "self": {
+                "href":
+                    "/api/users/userId/spaces/spaceId/grids/gridId/forms/formId",
+                "method": "get"
+              }
+            }
+          }
+        ]
+      },
       'name': 'New grid',
       'id': 'gridId',
       '_links': {

--- a/packages/apptive_grid_core/test/multi_cross_reference_test.dart
+++ b/packages/apptive_grid_core/test/multi_cross_reference_test.dart
@@ -246,12 +246,35 @@ void main() {
         ],
         'name': 'New Name',
         'title': 'New title',
+        'id': 'formId',
+        '_links': {
+          "submit": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "delete"
+          },
+          "self": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "get"
+          },
+          "update": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "put"
+          }
+        },
       };
 
       final formData = FormData.fromJson(responseWithMultiCrossReference);
 
       final fromJson =
-          formData.components[0] as MultiCrossReferenceFormComponent;
+          formData.components![0] as MultiCrossReferenceFormComponent;
 
       final directEntity = MultiCrossReferenceDataEntity.fromJson(
         jsonValue: [

--- a/packages/apptive_grid_core/test/multi_cross_reference_test.dart
+++ b/packages/apptive_grid_core/test/multi_cross_reference_test.dart
@@ -46,15 +46,94 @@ void main() {
           '_id': {'type': 'string'}
         }
       },
-      'name': 'New grid view'
+      'name': 'New grid view',
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
 
     test('Grid Parses Correctly', () {
       final grid = Grid.fromJson(rawResponse);
 
-      expect(grid.fields.length, equals(1));
+      expect(grid.fields!.length, equals(1));
       expect(
-        grid.rows[0].entries[0].data,
+        grid.rows![0].entries[0].data,
         MultiCrossReferenceDataEntity.fromJson(
           jsonValue: [
             {
@@ -76,7 +155,7 @@ void main() {
     });
 
     test('GridUri is parsed Correctly', () {
-      final dataEntity = Grid.fromJson(rawResponse).rows[0].entries[0].data
+      final dataEntity = Grid.fromJson(rawResponse).rows![0].entries[0].data
           as MultiCrossReferenceDataEntity;
 
       expect(

--- a/packages/apptive_grid_core/test/space_test.dart
+++ b/packages/apptive_grid_core/test/space_test.dart
@@ -2,77 +2,265 @@ import 'package:apptive_grid_core/apptive_grid_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('Parsing', () {
-    test('From Json maps correctly', () {
-      const id = 'id';
-      const name = 'name';
-      final grid = GridUri(user: 'user', space: id, grid: 'gridId');
+  group('Space', () {
+    group('Parsing', () {
+      test('From Json maps correctly', () {
+        const id = 'id';
+        const name = 'name';
+        final grid = GridUri(user: 'user', space: id, grid: 'gridId');
 
-      final jsonSpace = Space.fromJson({
-        'id': 'id',
-        'name': 'name',
-        'gridUris': [
-          '/api/users/user/spaces/id/grids/gridId',
-        ]
+        final jsonSpace = Space.fromJson({
+          'id': 'id',
+          'name': 'name',
+          'gridUris': [
+            '/api/users/user/spaces/id/grids/gridId',
+          ],
+          '_links': {
+            'self': {
+              'href': '/api/users/user/spaces/id',
+              'method': 'get',
+            }
+          },
+        });
+
+        expect(jsonSpace.id, equals(id));
+        expect(jsonSpace.name, equals(name));
+        expect(jsonSpace.gridUris!.length, equals(1));
+        expect(jsonSpace.gridUris![0], equals(grid));
+        expect(jsonSpace.links.length, equals(1));
       });
 
-      expect(jsonSpace.id, equals(id));
-      expect(jsonSpace.name, equals(name));
-      expect(jsonSpace.grids.length, equals(1));
-      expect(jsonSpace.grids[0], equals(grid));
+      test('From Json, toJson equals', () {
+        final jsonSpace = Space.fromJson({
+          'id': 'id',
+          'name': 'name',
+          'gridUris': [
+            '/api/users/user/spaces/id/grids/gridId',
+          ],
+          'type': 'space',
+          '_links': {
+            'self': {
+              'href': '/api/users/user/spaces/id',
+              'method': 'get',
+            }
+          },
+        });
+
+        final doubleParse = Space.fromJson(jsonSpace.toJson());
+
+        expect(doubleParse, equals(jsonSpace));
+      });
     });
 
-    test('From Json, toJson equals', () {
-      final jsonSpace = Space.fromJson({
-        'id': 'id',
-        'name': 'name',
-        'gridUris': [
-          '/api/users/user/spaces/id/grids/gridId',
-        ]
+    group('Equality', () {
+      test('Plain and From json equal', () {
+        const id = 'id';
+        const name = 'name';
+        final grid = GridUri(user: 'user', space: id, grid: 'gridId');
+
+        final plain = Space(
+          id: id,
+          name: name,
+          gridUris: [grid],
+          links: {
+            ApptiveLinkType.self: ApptiveLink(
+              uri: Uri.parse('/api/users/user/spaces/id'),
+              method: 'get',
+            ),
+          },
+        );
+
+        final jsonSpace = Space.fromJson({
+          'id': 'id',
+          'name': 'name',
+          'gridUris': [
+            '/api/users/user/spaces/id/grids/gridId',
+          ],
+          'type': 'space',
+          '_links': {
+            'self': {
+              'href': '/api/users/user/spaces/id',
+              'method': 'get',
+            }
+          },
+        });
+
+        expect(plain, equals(jsonSpace));
+        expect(plain.hashCode, equals(jsonSpace.hashCode));
       });
 
-      final doubleParse = Space.fromJson(jsonSpace.toJson());
+      test('Plain and From json not equal with different values', () {
+        const id = 'id';
+        const name = 'name';
 
-      expect(doubleParse, equals(jsonSpace));
+        final plain = Space(
+          id: id,
+          name: name,
+          gridUris: [],
+          links: {
+            ApptiveLinkType.self: ApptiveLink(
+              uri: Uri.parse('/api/users/user/spaces/id'),
+              method: 'get',
+            ),
+          },
+        );
+
+        final jsonSpace = Space.fromJson({
+          'id': 'id',
+          'name': 'name',
+          'type': 'space',
+          'gridUris': [
+            '/api/users/user/spaces/id/grids/gridId',
+          ]
+        });
+
+        expect(plain, isNot(jsonSpace));
+        expect(plain.hashCode, isNot(jsonSpace.hashCode));
+      });
     });
   });
 
-  group('Equality', () {
-    test('Plain and From json equal', () {
-      const id = 'id';
-      const name = 'name';
-      final grid = GridUri(user: 'user', space: id, grid: 'gridId');
+  group('sharedSpace', () {
+    group('Parsing', () {
+      test('From Json maps correctly', () {
+        const id = 'id';
+        const name = 'name';
+        final grid = GridUri(user: 'user', space: id, grid: 'gridId');
 
-      final plain = Space(id: id, name: name, grids: [grid]);
+        final jsonSharedSpace = SharedSpace.fromJson({
+          'id': 'id',
+          'name': 'name',
+          'gridUris': [
+            '/api/users/user/spaces/id/grids/gridId',
+          ],
+          'realSpace': 'realSpace.uri',
+          '_links': {
+            'self': {
+              'href': '/api/users/user/spaces/id',
+              'method': 'get',
+            }
+          },
+        });
 
-      final jsonSpace = Space.fromJson({
-        'id': 'id',
-        'name': 'name',
-        'gridUris': [
-          '/api/users/user/spaces/id/grids/gridId',
-        ]
+        expect(jsonSharedSpace.id, equals(id));
+        expect(jsonSharedSpace.name, equals(name));
+        expect(jsonSharedSpace.gridUris!.length, equals(1));
+        expect(jsonSharedSpace.gridUris![0], equals(grid));
+        expect(jsonSharedSpace.links.length, equals(1));
       });
 
-      expect(plain, equals(jsonSpace));
-      expect(plain.hashCode, equals(jsonSpace.hashCode));
+      test('From Json, toJson equals', () {
+        final jsonSharedSpace = SharedSpace.fromJson({
+          'id': 'id',
+          'name': 'name',
+          'gridUris': [
+            '/api/users/user/spaces/id/grids/gridId',
+          ],
+          'realSpace': 'realSpace.uri',
+          'type': 'sharedSpace',
+          '_links': {
+            'self': {
+              'href': '/api/users/user/spaces/id',
+              'method': 'get',
+            }
+          },
+        });
+
+        final doubleParse = SharedSpace.fromJson(jsonSharedSpace.toJson());
+
+        expect(doubleParse, equals(jsonSharedSpace));
+      });
+
+      test('Space.fromJson returns shared Space', () {
+        final space = Space.fromJson({'id': 'id',
+          'name': 'name',
+          'gridUris': [
+            '/api/users/user/spaces/id/grids/gridId',
+          ],
+          'type': 'sharedSpace',
+          'realSpace': 'realSpace.uri',
+          '_links': {
+            'self': {
+              'href': '/api/users/user/spaces/id',
+              'method': 'get',
+            }
+          },});
+
+        expect(space.runtimeType, equals(SharedSpace));
+      });
     });
 
-    test('Plain and From json not equal with different values', () {
-      const id = 'id';
-      const name = 'name';
+    group('Equality', () {
+      test('Plain and From json equal', () {
+        const id = 'id';
+        const name = 'name';
+        final grid = GridUri(user: 'user', space: id, grid: 'gridId');
+        final realSpace = Uri.parse('realSpace.uri');
 
-      final plain = Space(id: id, name: name, grids: []);
+        final plain = SharedSpace(
+          id: id,
+          name: name,
+          gridUris: [grid],
+          realSpace: realSpace,
+          links: {
+            ApptiveLinkType.self: ApptiveLink(
+              uri: Uri.parse('/api/users/user/spaces/id'),
+              method: 'get',
+            ),
+          },
+        );
 
-      final jsonSpace = Space.fromJson({
-        'id': 'id',
-        'name': 'name',
-        'gridUris': [
-          '/api/users/user/spaces/id/grids/gridId',
-        ]
+        final jsonSharedSpace = SharedSpace.fromJson({
+          'id': 'id',
+          'name': 'name',
+          'gridUris': [
+            '/api/users/user/spaces/id/grids/gridId',
+          ],
+          'realSpace': 'realSpace.uri',
+          'type': 'sharedSpace',
+          '_links': {
+            'self': {
+              'href': '/api/users/user/spaces/id',
+              'method': 'get',
+            }
+          },
+        });
+
+        expect(plain, equals(jsonSharedSpace));
+        expect(plain.hashCode, equals(jsonSharedSpace.hashCode));
       });
 
-      expect(plain, isNot(jsonSpace));
-      expect(plain.hashCode, isNot(jsonSpace.hashCode));
+      test('Plain and From json not equal with different values', () {
+        const id = 'id';
+        const name = 'name';
+        final realSpace = Uri.parse('realSpace.uri');
+
+        final plain = SharedSpace(
+          id: id,
+          name: name,
+          gridUris: [],
+          realSpace: realSpace,
+          links: {
+            ApptiveLinkType.self: ApptiveLink(
+              uri: Uri.parse('/api/users/user/spaces/id'),
+              method: 'get',
+            ),
+          },
+        );
+
+        final jsonSharedSpace = SharedSpace.fromJson({
+          'id': 'id',
+          'name': 'name',
+          'type': 'sharedSpace',
+          'gridUris': [
+            '/api/users/user/spaces/id/grids/gridId',
+          ],
+          'realSpace': 'realSpace.uri',
+        });
+
+        expect(plain, isNot(jsonSharedSpace));
+        expect(plain.hashCode, isNot(jsonSharedSpace.hashCode));
+      });
     });
   });
 }

--- a/packages/apptive_grid_core/test/space_test.dart
+++ b/packages/apptive_grid_core/test/space_test.dart
@@ -42,7 +42,21 @@ void main() {
             'self': {
               'href': '/api/users/user/spaces/id',
               'method': 'get',
-            }
+            },
+          },
+          '_embedded': {
+            'grids': [
+              {
+                'id': 'gridId',
+                'name': 'Grid',
+                '_links': {
+                  'self': {
+                    'href': '/api/users/user/spaces/id/grid/gridId',
+                    'method': 'get',
+                  },
+                },
+              },
+            ],
           },
         });
 
@@ -62,6 +76,19 @@ void main() {
           id: id,
           name: name,
           gridUris: [grid],
+          embeddedGrids: [
+            Grid(
+              id: 'gridId',
+              name: 'Grid',
+              schema: null,
+              links: {
+                ApptiveLinkType.self: ApptiveLink(
+                  uri: Uri.parse('/api/users/user/spaces/id/grids/gridId'),
+                  method: 'get',
+                )
+              },
+            ),
+          ],
           links: {
             ApptiveLinkType.self: ApptiveLink(
               uri: Uri.parse('/api/users/user/spaces/id'),
@@ -76,6 +103,20 @@ void main() {
           'gridUris': [
             '/api/users/user/spaces/id/grids/gridId',
           ],
+          '_embedded': {
+            'grids': [
+              {
+                'id': 'gridId',
+                'name': 'Grid',
+                '_links': {
+                  'self': {
+                    'href': '/api/users/user/spaces/id/grid/gridId',
+                    'method': 'get',
+                  },
+                },
+              },
+            ],
+          },
           'type': 'space',
           '_links': {
             'self': {
@@ -172,7 +213,8 @@ void main() {
       });
 
       test('Space.fromJson returns shared Space', () {
-        final space = Space.fromJson({'id': 'id',
+        final space = Space.fromJson({
+          'id': 'id',
           'name': 'name',
           'gridUris': [
             '/api/users/user/spaces/id/grids/gridId',
@@ -183,8 +225,9 @@ void main() {
             'self': {
               'href': '/api/users/user/spaces/id',
               'method': 'get',
-            }
-          },});
+            },
+          },
+        });
 
         expect(space.runtimeType, equals(SharedSpace));
       });
@@ -240,6 +283,18 @@ void main() {
           name: name,
           gridUris: [],
           realSpace: realSpace,
+          embeddedGrids: [
+            Grid(
+              id: 'gridId',
+              name: 'Grid',
+              links: {
+                ApptiveLinkType.self: ApptiveLink(
+                  uri: Uri.parse('/api/users/user/spaces/id/grids/gridId'),
+                  method: 'get',
+                ),
+              },
+            ),
+          ],
           links: {
             ApptiveLinkType.self: ApptiveLink(
               uri: Uri.parse('/api/users/user/spaces/id'),
@@ -256,6 +311,20 @@ void main() {
             '/api/users/user/spaces/id/grids/gridId',
           ],
           'realSpace': 'realSpace.uri',
+          '_embedded': {
+            'grids': [
+              {
+                'id': 'gridId',
+                'name': 'Grid',
+                '_links': {
+                  'self': {
+                    'href': '/api/users/user/spaces/id/grid/gridId',
+                    'method': 'get',
+                  },
+                },
+              },
+            ],
+          },
         });
 
         expect(plain, isNot(jsonSharedSpace));

--- a/packages/apptive_grid_core/test/user_reference_test.dart
+++ b/packages/apptive_grid_core/test/user_reference_test.dart
@@ -69,13 +69,92 @@ void main() {
         }
       },
       'name': 'Yeah Ansicht',
+      'id': 'gridId',
+      '_links': {
+        "addLink": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "method": "post"
+        },
+        "forms": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "get"
+        },
+        "updateFieldType": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+          "method": "post"
+        },
+        "removeField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "method": "post"
+        },
+        "addEntity": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "post"
+        },
+        "views": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "get"
+        },
+        "addView": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "method": "post"
+        },
+        "self": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "get"
+        },
+        "updateFieldKey": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+          "method": "post"
+        },
+        "query": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "method": "get"
+        },
+        "entities": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "method": "get"
+        },
+        "updates": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "method": "get"
+        },
+        "schema": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "method": "get"
+        },
+        "updateFieldName": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "method": "post"
+        },
+        "addForm": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "method": "post"
+        },
+        "addField": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "method": "post"
+        },
+        "rename": {
+          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "method": "post"
+        },
+        "remove": {
+          "href":
+              "/api/users/userId/spaces/spaceId/grids/61bb271d457c98231c8fbb04",
+          "method": "delete"
+        }
+      },
     };
 
     test('Grid Parses Correctly', () {
       final grid = Grid.fromJson(rawResponse);
 
-      expect(grid.fields.length, equals(1));
-      expect(grid.rows.length, equals(4));
+      expect(grid.fields!.length, equals(1));
+      expect(grid.rows!.length, equals(4));
     });
 
     group('UserReference Type', () {
@@ -83,14 +162,14 @@ void main() {
 
       test('Null', () {
         expect(
-          grid.rows[0].entries.first.data,
+          grid.rows![0].entries.first.data,
           UserReferenceDataEntity(),
         );
       });
 
       test('User', () {
         expect(
-          grid.rows[1].entries.first.data,
+          grid.rows![1].entries.first.data,
           UserReferenceDataEntity(
             const UserReference(
               id: 'userId',
@@ -104,7 +183,7 @@ void main() {
 
       test('Form Link', () {
         expect(
-          grid.rows[2].entries.first.data,
+          grid.rows![2].entries.first.data,
           UserReferenceDataEntity(
             const UserReference(
               id: '61eeac4686c4f1d22992f260',
@@ -118,7 +197,7 @@ void main() {
 
       test('Api Key', () {
         expect(
-          grid.rows[3].entries.first.data,
+          grid.rows![3].entries.first.data,
           UserReferenceDataEntity(
             const UserReference(
               id: '61eeac4686c4f1d22992f263',

--- a/packages/apptive_grid_core/test/user_reference_test.dart
+++ b/packages/apptive_grid_core/test/user_reference_test.dart
@@ -287,12 +287,35 @@ void main() {
             'fieldId': 'f3k9zj2aaclqnhd2e8cvlwydt',
             'type': 'textfield'
           }
-        ]
+        ],
+        'id': 'formId',
+        '_links': {
+          "submit": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "post"
+          },
+          "remove": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "delete"
+          },
+          "self": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "get"
+          },
+          "update": {
+            "href":
+                "/api/users/614c5440b50f51e3ea8a2a50/spaces/62600bf5d7f0d75408996f69/grids/62600bf9d7f0d75408996f6c/forms/6262aadbcd22c4725899a114",
+            "method": "put"
+          }
+        },
       };
 
       final formData = FormData.fromJson(responseWithUserReference);
 
-      final fromJson = formData.components[0] as UserReferenceFormComponent;
+      final fromJson = formData.components![0] as UserReferenceFormComponent;
 
       final directEntity = UserReferenceDataEntity.fromJson({
         'name': 'jane.doe@2denker.de',

--- a/packages/apptive_grid_core/test/user_test.dart
+++ b/packages/apptive_grid_core/test/user_test.dart
@@ -17,15 +17,47 @@ void main() {
         'email': 'jane.doe@zweidenker.de',
         'spaceUris': [
           '/api/users/id/spaces/spaceId',
-        ]
+        ],
+        '_links': 
+          {
+            "accessCredentials": {
+              "href": "/api/users/id/accessKeys",
+              "method": "get"
+            },
+            "spaces": {
+              "href": "/api/users/id/spaces",
+              "method": "get"
+            },
+            "hooks": {
+              "href": "/api/users/id/hooks",
+              "method": "get"
+            },
+            "addHook": {
+              "href": "/api/users/id/hooks",
+              "method": "post"
+            },
+            "self": {
+              "href": "/api/users/id",
+              "method": "get"
+            },
+            "addAccessCredentials": {
+              "href": "/api/users/id/accessKeys",
+              "method": "post"
+            },
+            "addSpace": {
+              "href": "/api/users/id/spaces",
+              "method": "post"
+          },
+        },
       });
 
       expect(jsonUser.id, equals(id));
       expect(jsonUser.firstName, equals(firstName));
       expect(jsonUser.lastName, equals(lastName));
       expect(jsonUser.email, equals(email));
-      expect(jsonUser.spaces.length, equals(1));
-      expect(jsonUser.spaces[0], equals(spaceUri));
+      expect(jsonUser.spaceUris.length, equals(1));
+      expect(jsonUser.spaceUris[0], equals(spaceUri));
+      expect(jsonUser.links.length, equals(7));
     });
 
     test('From Json, toJson equals', () {
@@ -36,7 +68,10 @@ void main() {
         'email': 'jane.doe@zweidenker.de',
         'spaceUris': [
           '/api/users/id/spaces/spaceId',
-        ]
+        ],
+        '_links': {
+          'self': {'href': '/api/users/id', 'method': 'get'},
+        },
       });
 
       final doubleParse = User.fromJson(jsonUser.toJson());
@@ -58,7 +93,10 @@ void main() {
         lastName: lastName,
         firstName: firstName,
         id: id,
-        spaces: [spaceUri],
+        spaceUris: [spaceUri],
+        links: {
+          ApptiveLinkType.self: ApptiveLink(uri: Uri.parse('/api/users/id'), method: 'get'),
+        },
       );
 
       final jsonUser = User.fromJson({
@@ -68,7 +106,10 @@ void main() {
         'email': 'jane.doe@zweidenker.de',
         'spaceUris': [
           '/api/users/id/spaces/spaceId',
-        ]
+        ],
+        '_links': {
+          'self': {'href': '/api/users/id', 'method': 'get'},
+        },
       });
 
       expect(plain, equals(jsonUser));
@@ -86,7 +127,8 @@ void main() {
         lastName: lastName,
         firstName: firstName,
         id: id,
-        spaces: [],
+        spaceUris: [],
+        links: {},
       );
 
       final jsonUser = User.fromJson({
@@ -96,7 +138,10 @@ void main() {
         'email': 'jane.doe@zweidenker.de',
         'spaceUris': [
           '/api/users/id/spaces/spaceId',
-        ]
+        ],
+        '_links': {
+          'self': {'href': '/api/users/id', 'method': 'get'},
+        },
       });
 
       expect(plain, isNot(jsonUser));

--- a/packages/apptive_grid_core/test/user_test.dart
+++ b/packages/apptive_grid_core/test/user_test.dart
@@ -18,36 +18,20 @@ void main() {
         'spaceUris': [
           '/api/users/id/spaces/spaceId',
         ],
-        '_links': 
-          {
-            "accessCredentials": {
-              "href": "/api/users/id/accessKeys",
-              "method": "get"
-            },
-            "spaces": {
-              "href": "/api/users/id/spaces",
-              "method": "get"
-            },
-            "hooks": {
-              "href": "/api/users/id/hooks",
-              "method": "get"
-            },
-            "addHook": {
-              "href": "/api/users/id/hooks",
-              "method": "post"
-            },
-            "self": {
-              "href": "/api/users/id",
-              "method": "get"
-            },
-            "addAccessCredentials": {
-              "href": "/api/users/id/accessKeys",
-              "method": "post"
-            },
-            "addSpace": {
-              "href": "/api/users/id/spaces",
-              "method": "post"
+        '_links': {
+          "accessCredentials": {
+            "href": "/api/users/id/accessKeys",
+            "method": "get"
           },
+          "spaces": {"href": "/api/users/id/spaces", "method": "get"},
+          "hooks": {"href": "/api/users/id/hooks", "method": "get"},
+          "addHook": {"href": "/api/users/id/hooks", "method": "post"},
+          "self": {"href": "/api/users/id", "method": "get"},
+          "addAccessCredentials": {
+            "href": "/api/users/id/accessKeys",
+            "method": "post"
+          },
+          "addSpace": {"href": "/api/users/id/spaces", "method": "post"},
         },
       });
 
@@ -95,7 +79,8 @@ void main() {
         id: id,
         spaceUris: [spaceUri],
         links: {
-          ApptiveLinkType.self: ApptiveLink(uri: Uri.parse('/api/users/id'), method: 'get'),
+          ApptiveLinkType.self:
+              ApptiveLink(uri: Uri.parse('/api/users/id'), method: 'get'),
         },
       );
 

--- a/packages/apptive_grid_form/CHANGELOG.md
+++ b/packages/apptive_grid_form/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0-alpha.1
+* Update Core Package
+* Includes a lot of breaking changes in the Models. Including in `FormData`
+
 ## 0.9.1
 * Use new Attachment System
 * Show Error Message in Form Error

--- a/packages/apptive_grid_form/lib/apptive_grid_form.dart
+++ b/packages/apptive_grid_form/lib/apptive_grid_form.dart
@@ -300,11 +300,12 @@ class ApptiveGridFormDataState extends State<ApptiveGridFormData> {
       child: Form(
         key: _formKey,
         child: ListView.builder(
-          itemCount: 1 + data.components.length + data.actions.length,
+          itemCount:
+              1 + (data.components?.length ?? 0) + (data.actions?.length ?? 0),
           itemBuilder: (context, index) {
             // Title
             if (index == 0) {
-              if (widget.hideTitle) {
+              if (widget.hideTitle || data.title == null) {
                 return const SizedBox();
               } else {
                 return Padding(
@@ -312,15 +313,15 @@ class ApptiveGridFormDataState extends State<ApptiveGridFormData> {
                       widget.contentPadding ??
                       _defaultPadding,
                   child: Text(
-                    data.title,
+                    data.title!,
                     style: widget.titleStyle ??
                         Theme.of(context).textTheme.headline5,
                   ),
                 );
               }
-            } else if (index < data.components.length + 1) {
+            } else if (index < (data.components?.length ?? 0) + 1) {
               final componentIndex = index - 1;
-              final component = fromModel(data.components[componentIndex]);
+              final component = fromModel(data.components![componentIndex]);
               if (component is UserReferenceFormWidget) {
                 // UserReference Widget should be invisible in the Form
                 // So returning without any Padding
@@ -330,7 +331,7 @@ class ApptiveGridFormDataState extends State<ApptiveGridFormData> {
                   padding: widget.contentPadding ?? _defaultPadding,
                   child: Builder(
                     builder: (context) {
-                      return fromModel(data.components[componentIndex]);
+                      return fromModel(data.components![componentIndex]);
                     },
                   ),
                 );
@@ -340,15 +341,16 @@ class ApptiveGridFormDataState extends State<ApptiveGridFormData> {
                 padding: widget.contentPadding ?? _defaultPadding,
                 child: Builder(
                   builder: (_) {
-                    final actionIndex = index - 1 - data.components.length;
-                    final action = data.actions[actionIndex];
+                    final actionIndex =
+                        index - 1 - (data.components?.length ?? 0);
+                    final action = data.actions![actionIndex];
                     if (_actionsInProgress.contains(action)) {
                       return const Center(
                         child: CircularProgressIndicator.adaptive(),
                       );
                     } else {
                       return ActionButton(
-                        action: data.actions[actionIndex],
+                        action: action,
                         onPressed: _performAction,
                         child: Text(localization.actionSend),
                       );

--- a/packages/apptive_grid_form/lib/widgets/form_widget/cross_reference/cross_reference_dropdown_button_form_field.dart
+++ b/packages/apptive_grid_form/lib/widgets/form_widget/cross_reference/cross_reference_dropdown_button_form_field.dart
@@ -89,7 +89,7 @@ class _CrossReferenceDropdownButtonFormFieldState<T extends DataEntity>
     ApptiveGrid.getClient(context, listen: false)
         .loadGrid(gridUri: _gridUri)
         .then((value) {
-      for (final row in value.rows) {
+      for (final row in (value.rows ?? [])) {
         _controllers[row.id]?.dispose();
         _controllers[row.id] = _scrollControllerGroup.addAndGet();
       }
@@ -185,7 +185,7 @@ class _CrossReferenceDropdownButtonFormFieldState<T extends DataEntity>
         enabled: false,
         value: null,
         child: HeaderRowWidget(
-          fields: _grid!.fields,
+          fields: _grid!.fields ?? [],
           controller: _headerController,
         ),
       );
@@ -196,9 +196,9 @@ class _CrossReferenceDropdownButtonFormFieldState<T extends DataEntity>
         child: ListView.builder(
           shrinkWrap: true,
           physics: const BouncingScrollPhysics(),
-          itemCount: _grid!.rows.length,
+          itemCount: _grid!.rows?.length ?? 0,
           itemBuilder: (context, index) {
-            final row = _grid!.rows[index];
+            final row = _grid!.rows![index];
             String path = _gridUri.uri.path;
             final viewsIndex = path.indexOf('/views');
             if (viewsIndex > 0) {
@@ -304,9 +304,10 @@ class _RowMenuItemState extends State<_RowMenuItem> {
   @override
   Widget build(BuildContext context) {
     final index = widget.grid.rows
-        .where((row) => row.matchesFilter(widget.filterController?.query))
-        .toList()
-        .indexOf(widget.row);
+            ?.where((row) => row.matchesFilter(widget.filterController?.query))
+            .toList()
+            .indexOf(widget.row) ??
+        0;
     return GridRowWidget(
       row: widget.row,
       scrollController: widget.controller,

--- a/packages/apptive_grid_form/pubspec.yaml
+++ b/packages/apptive_grid_form/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_form
 description: A Flutter Package to display ApptiveGrid Forms inside a Flutter App.
-version: 0.9.1-alpha.2
+version: 0.10.0-alpha.1
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_form
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  apptive_grid_core: ^0.9.3
+  apptive_grid_core: ^0.10.0-alpha.1
   file_picker: ^4.3.0
   flutter:
     sdk: flutter

--- a/packages/apptive_grid_form/test/apptive_grid_form_test.dart
+++ b/packages/apptive_grid_form/test/apptive_grid_form_test.dart
@@ -20,7 +20,13 @@ void main() {
     registerFallbackValue(
       ActionItem(
         action: FormAction('', ''),
-        data: FormData(title: '', components: [], schema: null),
+        data: FormData(
+          id: 'formId',
+          title: '',
+          components: [],
+          schema: null,
+          links: {},
+        ),
       ),
     );
   });
@@ -45,11 +51,13 @@ void main() {
         () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
       ).thenAnswer(
         (realInvocation) async => FormData(
+          id: 'formId',
           name: 'Form Name',
           title: 'Form Title',
           components: [],
           actions: [],
           schema: {},
+          links: {},
         ),
       );
 
@@ -74,11 +82,13 @@ void main() {
         () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
       ).thenAnswer(
         (realInvocation) async => FormData(
+          id: 'formId',
           name: 'Form Name',
           title: 'Form Title',
           components: [],
           actions: [],
           schema: {},
+          links: {},
         ),
       );
 
@@ -91,11 +101,13 @@ void main() {
 
   testWidgets('OnLoadedCallback gets called', (tester) async {
     final form = FormData(
+      id: 'formId',
       name: 'Form Name',
       title: 'Form Title',
       components: [],
       actions: [],
       schema: {},
+      links: {},
     );
     final completer = Completer<FormData>();
     final target = TestApp(
@@ -131,11 +143,13 @@ void main() {
         ),
       );
       final form = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [],
         actions: [],
         schema: {},
+        links: {},
       );
       when(
         () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
@@ -164,10 +178,12 @@ void main() {
       );
       final action = FormAction('uri', 'method');
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [],
         actions: [action],
+        links: {},
         schema: {},
       );
 
@@ -198,10 +214,12 @@ void main() {
       );
       final action = FormAction('uri', 'method');
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [],
         actions: [action],
+        links: {},
         schema: {},
       );
 
@@ -288,10 +306,12 @@ void main() {
         );
         final action = FormAction('uri', 'method');
         final formData = FormData(
+          id: 'formId',
           name: 'Form Name',
           title: 'Form Title',
           components: [],
           actions: [action],
+          links: {},
           schema: {},
         );
 
@@ -322,10 +342,12 @@ void main() {
         );
         final action = FormAction('uri', 'method');
         final formData = FormData(
+          id: 'formId',
           name: 'Form Name',
           title: 'Form Title',
           components: [],
           actions: [action],
+          links: {},
           schema: {},
         );
 
@@ -357,10 +379,12 @@ void main() {
         );
         final action = FormAction('uri', 'method');
         final formData = FormData(
+          id: 'formId',
           name: 'Form Name',
           title: 'Form Title',
           components: [],
           actions: [action],
+          links: {},
           schema: {},
         );
 
@@ -408,10 +432,12 @@ void main() {
         );
         final action = FormAction('uri', 'method');
         final formData = FormData(
+          id: 'formId',
           name: 'Form Name',
           title: 'Form Title',
           components: [],
           actions: [action],
+          links: {},
           schema: {},
         );
 
@@ -447,10 +473,12 @@ void main() {
         );
         final action = FormAction('uri', 'method');
         final formData = FormData(
+          id: 'formId',
           name: 'Form Name',
           title: 'Form Title',
           components: [],
           actions: [action],
+          links: {},
           schema: {},
         );
 
@@ -481,10 +509,12 @@ void main() {
         );
         final action = FormAction('uri', 'method');
         final formData = FormData(
+          id: 'formId',
           name: 'Form Name',
           title: 'Form Title',
           components: [],
           actions: [action],
+          links: {},
           schema: {},
         );
 
@@ -522,10 +552,12 @@ void main() {
       );
       final action = FormAction('uri', 'method');
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [],
         actions: [action],
+        links: {},
         schema: {},
       );
 
@@ -557,10 +589,12 @@ void main() {
       );
       final action = FormAction('uri', 'method');
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [],
         actions: [action],
+        links: {},
         schema: {},
       );
 
@@ -584,10 +618,12 @@ void main() {
 
     final action = FormAction('actionUri', 'POST');
     final data = FormData(
+      id: 'formId',
       name: 'Form Name',
       title: 'Title',
       components: [],
       actions: [action],
+      links: {},
       schema: {},
     );
 
@@ -684,11 +720,13 @@ void main() {
     testWidgets('Current Data returns data', (tester) async {
       final key = GlobalKey<ApptiveGridFormDataState>();
       final form = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [],
         actions: [],
         schema: {},
+        links: {},
       );
       final target = TestApp(
         client: client,
@@ -720,10 +758,12 @@ void main() {
       final key = GlobalKey<ApptiveGridFormDataState>();
       final action = FormAction('uri', 'method');
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [],
         actions: [action],
+        links: {},
         schema: {},
       );
       final target = TestApp(
@@ -760,10 +800,12 @@ void main() {
       final key = GlobalKey<ApptiveGridFormDataState>();
       final action = FormAction('uri', 'method');
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [],
         actions: [action],
+        links: {},
         schema: {},
       );
       final target = TestApp(
@@ -810,10 +852,12 @@ void main() {
       );
       final action = FormAction('uri', 'method');
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [],
         actions: [action],
+        links: {},
         schema: {},
       );
 
@@ -844,6 +888,7 @@ void main() {
     testWidgets('UserReference Form Widget is build without padding',
         (tester) async {
       final formData = FormData(
+        id: 'formId',
         title: 'Form Data',
         components: [
           UserReferenceFormComponent(
@@ -852,6 +897,7 @@ void main() {
             fieldId: 'field3',
           ),
         ],
+        links: {},
         schema: {
           'properties': {
             'field3': {
@@ -904,9 +950,11 @@ void main() {
       when(client.sendPendingActions).thenAnswer((_) async {});
       when(() => client.loadForm(formUri: any(named: 'formUri'))).thenAnswer(
         (_) async => FormData(
+          id: 'formId',
           title: 'title',
           components: [],
           schema: {},
+          links: {},
         ),
       );
 

--- a/packages/apptive_grid_form/test/attachment_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/attachment_form_widget_test.dart
@@ -16,7 +16,13 @@ import 'common.dart';
 void main() {
   setUpAll(() {
     registerFallbackValue(
-      FormData(title: 'title', components: [], schema: null),
+      FormData(
+        id: 'formId',
+        title: 'title',
+        components: [],
+        schema: null,
+        links: {},
+      ),
     );
   });
 
@@ -50,6 +56,7 @@ void main() {
         );
         final action = FormAction('formAction', 'POST');
         final formData = FormData(
+          id: 'formId',
           title: 'title',
           components: [
             AttachmentFormComponent(
@@ -59,6 +66,7 @@ void main() {
             )
           ],
           actions: [action],
+          links: {},
           schema: null,
         );
         final client = MockApptiveGridClient();
@@ -105,7 +113,7 @@ void main() {
             verify(() => client.performAction(action, captureAny())).captured;
         expect(captured.length, equals(1));
         final submittedData = captured.first as FormData;
-        expect(submittedData.components.first.data, equals(data));
+        expect(submittedData.components!.first.data, equals(data));
       });
 
       testWidgets('Multiple Attachments get added', (tester) async {
@@ -147,6 +155,7 @@ void main() {
         );
         final action = FormAction('formAction', 'POST');
         final formData = FormData(
+          id: 'formId',
           title: 'title',
           components: [
             AttachmentFormComponent(
@@ -156,6 +165,7 @@ void main() {
             )
           ],
           actions: [action],
+          links: {},
           schema: null,
         );
         final client = MockApptiveGridClient();
@@ -205,7 +215,7 @@ void main() {
             verify(() => client.performAction(action, captureAny())).captured;
         expect(captured.length, equals(1));
         final submittedData =
-            captured.first.components.first.data as AttachmentDataEntity;
+            captured.first.components!.first.data as AttachmentDataEntity;
         expect(submittedData.value!.length, equals(2));
         expect(submittedData.value!.first, equals(attachment1));
         expect(submittedData.value!.last, equals(attachment2));
@@ -229,6 +239,7 @@ void main() {
 
         final action = FormAction('formAction', 'POST');
         final formData = FormData(
+          id: 'formId',
           title: 'title',
           components: [
             AttachmentFormComponent(
@@ -238,6 +249,7 @@ void main() {
             )
           ],
           actions: [action],
+          links: {},
           schema: null,
         );
         final client = MockApptiveGridClient();
@@ -324,6 +336,7 @@ void main() {
         );
         final action = FormAction('formAction', 'POST');
         final formData = FormData(
+          id: 'formId',
           title: 'title',
           components: [
             AttachmentFormComponent(
@@ -333,6 +346,7 @@ void main() {
             )
           ],
           actions: [action],
+          links: {},
           schema: null,
         );
         final client = MockApptiveGridClient();
@@ -379,7 +393,7 @@ void main() {
             verify(() => client.performAction(action, captureAny())).captured;
         expect(captured.length, equals(1));
         final submittedData = captured.first as FormData;
-        expect(submittedData.components.first.data, equals(data));
+        expect(submittedData.components!.first.data, equals(data));
       });
 
       testWidgets('Multiple Attachments from file picker get added',
@@ -423,6 +437,7 @@ void main() {
         );
         final action = FormAction('formAction', 'POST');
         final formData = FormData(
+          id: 'formId',
           title: 'title',
           components: [
             AttachmentFormComponent(
@@ -432,6 +447,7 @@ void main() {
             )
           ],
           actions: [action],
+          links: {},
           schema: null,
         );
         final client = MockApptiveGridClient();
@@ -481,7 +497,7 @@ void main() {
             verify(() => client.performAction(action, captureAny())).captured;
         expect(captured.length, equals(1));
         final submittedData =
-            captured.first.components.first.data as AttachmentDataEntity;
+            captured.first.components!.first.data as AttachmentDataEntity;
         expect(submittedData.value!.length, equals(2));
         expect(submittedData.value!.first, equals(attachment1));
         expect(submittedData.value!.last, equals(attachment2));
@@ -538,6 +554,7 @@ void main() {
         );
         final action = FormAction('formAction', 'POST');
         final formData = FormData(
+          id: 'formId',
           title: 'title',
           components: [
             AttachmentFormComponent(
@@ -547,6 +564,7 @@ void main() {
             )
           ],
           actions: [action],
+          links: {},
           schema: null,
         );
         final client = MockApptiveGridClient();
@@ -593,7 +611,7 @@ void main() {
             verify(() => client.performAction(action, captureAny())).captured;
         expect(captured.length, equals(1));
         final submittedData = captured.first as FormData;
-        expect(submittedData.components.first.data, equals(data));
+        expect(submittedData.components!.first.data, equals(data));
       });
 
       testWidgets(
@@ -607,6 +625,7 @@ void main() {
 
         final action = FormAction('formAction', 'POST');
         final formData = FormData(
+          id: 'formId',
           title: 'title',
           components: [
             AttachmentFormComponent(
@@ -616,6 +635,7 @@ void main() {
             )
           ],
           actions: [action],
+          links: {},
           schema: null,
         );
         final client = MockApptiveGridClient();
@@ -671,6 +691,7 @@ void main() {
       );
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           AttachmentFormComponent(
@@ -680,6 +701,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();
@@ -725,7 +747,7 @@ void main() {
           verify(() => client.performAction(action, captureAny())).captured;
       expect(captured.length, equals(1));
       final submittedData = captured.first as FormData;
-      expect(submittedData.components.first.data, equals(data));
+      expect(submittedData.components!.first.data, equals(data));
     });
 
     testWidgets('Existing Attachment gets deleted', (tester) async {
@@ -742,6 +764,7 @@ void main() {
       );
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           AttachmentFormComponent(
@@ -751,6 +774,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();
@@ -776,7 +800,7 @@ void main() {
           verify(() => client.performAction(action, captureAny())).captured;
       expect(captured.length, equals(1));
       final submittedData = captured.first as FormData;
-      expect(submittedData.components.first.data, equals(data));
+      expect(submittedData.components!.first.data, equals(data));
     });
   });
 
@@ -784,6 +808,7 @@ void main() {
     testWidgets('Attachment is required shows message', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           AttachmentFormComponent(
@@ -794,6 +819,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();
@@ -823,6 +849,7 @@ void main() {
     testWidgets('Attachment is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           AttachmentFormComponent(
@@ -835,6 +862,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();
@@ -892,6 +920,7 @@ void main() {
       );
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           AttachmentFormComponent(
@@ -902,6 +931,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();
@@ -956,7 +986,7 @@ void main() {
           verify(() => client.performAction(action, captureAny<FormData>()))
               .captured
               .first as FormData;
-      expect(capturedData.components.first.data, equals(data));
+      expect(capturedData.components!.first.data, equals(data));
     });
   });
 }

--- a/packages/apptive_grid_form/test/boolean_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/boolean_form_widget_test.dart
@@ -8,13 +8,22 @@ import 'common.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FormData(title: 'title', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(
+        id: 'id',
+        title: 'title',
+        components: [],
+        schema: {},
+        links: {},
+      ),
+    );
   });
 
   group('Validation', () {
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           BooleanFormComponent(
@@ -25,6 +34,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();

--- a/packages/apptive_grid_form/test/component_test.dart
+++ b/packages/apptive_grid_form/test/component_test.dart
@@ -14,11 +14,13 @@ void main() {
   setUpAll(() {
     registerFallbackValue(
       FormData(
+        id: 'formId',
         name: 'name',
         title: 'title',
         components: [],
         actions: [],
         schema: {},
+        links: {},
       ),
     );
   });
@@ -64,10 +66,12 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('string'),
       );
       final target = TestApp(
@@ -100,7 +104,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final result = await completer.future;
-      expect(result.components.first.data.value, equals('Value'));
+      expect(result.components!.first.data.value, equals('Value'));
     });
 
     testWidgets('Required shows Error', (tester) async {
@@ -116,10 +120,12 @@ void main() {
         required: true,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('string'),
       );
       final target = TestApp(
@@ -162,10 +168,12 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('string', format: 'date-time'),
       );
       final target = TestApp(
@@ -210,7 +218,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final result = await completer.future;
-      expect(result.components.first.data.value, equals(date));
+      expect(result.components!.first.data.value, equals(date));
     });
 
     testWidgets('Value is send and used with Time Picker', (tester) async {
@@ -226,10 +234,12 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('string', format: 'date-time'),
       );
       final target = TestApp(
@@ -274,7 +284,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final result = await completer.future
-          .then((data) => data.components.first.data.value as DateTime);
+          .then((data) => data.components!.first.data.value as DateTime);
       expect(
         DateTime(
           result.year,
@@ -300,10 +310,12 @@ void main() {
         required: true,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('string', format: 'date-time'),
       );
       final target = TestApp(
@@ -346,10 +358,12 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('string', format: 'date'),
       );
       final target = TestApp(
@@ -393,7 +407,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final result = await completer.future;
-      expect(result.components.first.data.value, equals(date));
+      expect(result.components!.first.data.value, equals(date));
     });
 
     testWidgets('Required shows Error', (tester) async {
@@ -409,10 +423,12 @@ void main() {
         required: true,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('string', format: 'date'),
       );
       final target = TestApp(
@@ -455,10 +471,12 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('integer'),
       );
       final target = TestApp(
@@ -491,7 +509,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final result = await completer.future;
-      expect(result.components.first.data.value, equals(12));
+      expect(result.components!.first.data.value, equals(12));
     });
 
     testWidgets('Prefilled Value gets displayed', (tester) async {
@@ -503,11 +521,13 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [],
         schema: getSchema('integer'),
+        links: {},
       );
       final target = TestApp(
         client: client,
@@ -541,10 +561,12 @@ void main() {
         required: true,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('integer'),
       );
       final target = TestApp(
@@ -587,10 +609,12 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('number'),
       );
       final target = TestApp(
@@ -623,7 +647,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final result = await completer.future;
-      expect(result.components.first.data.value, equals(12));
+      expect(result.components!.first.data.value, equals(12));
     });
 
     testWidgets('Prefilled Value gets displayed', (tester) async {
@@ -635,11 +659,13 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [],
         schema: getSchema('number'),
+        links: {},
       );
       final target = TestApp(
         client: client,
@@ -673,10 +699,12 @@ void main() {
         required: true,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('number'),
       );
       final target = TestApp(
@@ -719,10 +747,12 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('boolean'),
       );
       final target = TestApp(
@@ -755,7 +785,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final result = await completer.future;
-      expect(result.components.first.data.value, equals(true));
+      expect(result.components!.first.data.value, equals(true));
     });
 
     testWidgets('Required shows Error', (tester) async {
@@ -771,10 +801,12 @@ void main() {
         required: true,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('boolean'),
       );
       final target = TestApp(
@@ -817,10 +849,12 @@ void main() {
         required: false,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema('string', options: ['value', 'newValue']),
       );
       final target = TestApp(
@@ -857,7 +891,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final result = await completer.future;
-      expect(result.components.first.data.value, equals('newValue'));
+      expect(result.components!.first.data.value, equals('newValue'));
     });
 
     testWidgets('Required shows Error', (tester) async {
@@ -873,10 +907,12 @@ void main() {
         required: true,
       );
       final formData = FormData(
+        id: 'formId',
         name: 'Form Name',
         title: 'Form Title',
         components: [component],
         actions: [action],
+        links: {},
         schema: getSchema(
           'string',
           options: [

--- a/packages/apptive_grid_form/test/cross_reference_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/cross_reference_form_widget_test.dart
@@ -11,7 +11,15 @@ import 'common.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FormData(title: 'title', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(
+        id: 'id',
+        title: 'title',
+        components: [],
+        schema: {},
+        links: {},
+      ),
+    );
     registerFallbackValue(GridUri(user: 'user', space: 'space', grid: 'grid'));
   });
 
@@ -219,6 +227,7 @@ void main() {
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           CrossReferenceFormComponent(
@@ -238,6 +247,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();

--- a/packages/apptive_grid_form/test/cross_reference_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/cross_reference_form_widget_test.dart
@@ -23,6 +23,7 @@ void main() {
     final gridUri = GridUri(user: 'user', space: 'space', grid: 'grid');
     final field = GridField('field', 'Name', DataType.text);
     final grid = Grid(
+      id: 'grid',
       name: 'Test',
       schema: null,
       fields: [field],
@@ -30,6 +31,13 @@ void main() {
         GridRow('row1', [GridEntry(field, StringDataEntity('First'))]),
         GridRow('row2', [GridEntry(field, StringDataEntity('Second'))]),
       ],
+      links: {
+        ApptiveLinkType.self: ApptiveLink(uri: gridUri.uri, method: 'get'),
+        ApptiveLinkType.entities: ApptiveLink(
+          uri: gridUri.uri.replace(path: '${gridUri.uri.path}/entities'),
+          method: 'get',
+        ),
+      },
     );
 
     setUp(() {
@@ -174,12 +182,20 @@ void main() {
 
     testWidgets('Empty null values', (tester) async {
       final gridWithNull = Grid(
+        id: 'grid',
         name: 'Test',
         schema: null,
         fields: [field],
         rows: [
           GridRow('row1', [GridEntry(field, StringDataEntity())]),
         ],
+        links: {
+          ApptiveLinkType.self: ApptiveLink(uri: gridUri.uri, method: 'get'),
+          ApptiveLinkType.entities: ApptiveLink(
+            uri: gridUri.uri.replace(path: '${gridUri.uri.path}/entities'),
+            method: 'get',
+          ),
+        },
       );
 
       when(() => client.loadGrid(gridUri: gridUri))
@@ -226,8 +242,14 @@ void main() {
       );
       final client = MockApptiveGridClient();
       when(() => client.loadGrid(gridUri: any(named: 'gridUri'))).thenAnswer(
-        (invocation) async =>
-            Grid(name: 'name', schema: {}, fields: [], rows: []),
+        (invocation) async => Grid(
+          id: 'grid',
+          name: 'name',
+          schema: {},
+          fields: [],
+          rows: [],
+          links: {},
+        ),
       );
       when(() => client.sendPendingActions()).thenAnswer((_) => Future.value());
       when(() => client.performAction(action, any()))

--- a/packages/apptive_grid_form/test/date_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/date_form_widget_test.dart
@@ -10,7 +10,15 @@ import 'common.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FormData(title: 'title', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(
+        id: 'id',
+        title: 'title',
+        components: [],
+        schema: {},
+        links: {},
+      ),
+    );
   });
 
   group('Localization', () {
@@ -80,6 +88,7 @@ void main() {
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           DateFormComponent(
@@ -90,6 +99,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();

--- a/packages/apptive_grid_form/test/date_time_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/date_time_form_widget_test.dart
@@ -10,7 +10,15 @@ import 'common.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FormData(title: 'title', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(
+        id: 'id',
+        links: {},
+        title: 'title',
+        components: [],
+        schema: {},
+      ),
+    );
   });
 
   group('Localization', () {
@@ -82,6 +90,7 @@ void main() {
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           DateTimeFormComponent(
@@ -92,6 +101,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();

--- a/packages/apptive_grid_form/test/decimal_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/decimal_form_widget_test.dart
@@ -9,7 +9,15 @@ import 'common.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FormData(title: 'title', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(
+        id: 'id',
+        links: {},
+        title: 'title',
+        components: [],
+        schema: {},
+      ),
+    );
   });
 
   group('Input Sanitation', () {
@@ -62,6 +70,7 @@ void main() {
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           DecimalFormComponent(
@@ -72,6 +81,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();

--- a/packages/apptive_grid_form/test/enum_collection_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/enum_collection_form_widget_test.dart
@@ -10,7 +10,13 @@ import 'common.dart';
 void main() {
   setUpAll(() {
     registerFallbackValue(
-      FormData(title: 'title', components: [], schema: null),
+      FormData(
+        id: 'formId',
+        links: {},
+        title: 'title',
+        components: [],
+        schema: null,
+      ),
     );
   });
 
@@ -80,6 +86,7 @@ void main() {
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           EnumCollectionFormComponent(
@@ -93,6 +100,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();
@@ -135,11 +143,13 @@ void main() {
 
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           component,
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();
@@ -193,7 +203,7 @@ void main() {
           verify(() => client.performAction(action, captureAny<FormData>()))
               .captured
               .first as FormData;
-      expect(capturedData.components.first.data.value, equals({'A'}));
+      expect(capturedData.components!.first.data.value, equals({'A'}));
     });
   });
 }

--- a/packages/apptive_grid_form/test/geolocation_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/geolocation_form_widget_test.dart
@@ -26,7 +26,9 @@ void main() {
     registerFallbackValue(PolygonUpdates.from({}, {}));
     registerFallbackValue(PolylineUpdates.from({}, {}));
     registerFallbackValue(CameraUpdate.newLatLng(const LatLng(0, 0)));
-    registerFallbackValue(FormData(title: '', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(id: 'id', links: {}, title: '', components: [], schema: {}),
+    );
   });
 
   group('TextInput', () {
@@ -43,6 +45,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -53,6 +56,7 @@ void main() {
                 fieldId: 'fieldId',
               ),
             ],
+            links: {},
             schema: null,
           ),
         ),
@@ -103,6 +107,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -113,6 +118,7 @@ void main() {
                 fieldId: 'fieldId',
               ),
             ],
+            links: {},
             schema: null,
           ),
         ),
@@ -206,6 +212,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -214,6 +221,7 @@ void main() {
                 fieldId: 'fieldId',
               ),
             ],
+            links: {},
             schema: null,
           ),
         ),
@@ -303,6 +311,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -312,6 +321,7 @@ void main() {
               ),
             ],
             schema: null,
+            links: {},
           ),
         ),
       );
@@ -381,6 +391,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -390,6 +401,7 @@ void main() {
               ),
             ],
             schema: null,
+            links: {},
           ),
         ),
       );
@@ -481,6 +493,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -490,6 +503,7 @@ void main() {
               ),
             ],
             schema: null,
+            links: {},
           ),
         ),
       );
@@ -609,6 +623,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -618,6 +633,7 @@ void main() {
               ),
             ],
             schema: null,
+            links: {},
           ),
         ),
       );
@@ -727,6 +743,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -736,6 +753,7 @@ void main() {
               ),
             ],
             schema: null,
+            links: {},
           ),
         ),
       );
@@ -925,6 +943,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -934,6 +953,7 @@ void main() {
               ),
             ],
             schema: null,
+            links: {},
           ),
         ),
       );
@@ -1017,6 +1037,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -1026,6 +1047,7 @@ void main() {
               ),
             ],
             schema: null,
+            links: {},
           ),
         ),
       );
@@ -1151,6 +1173,7 @@ void main() {
         options: const ApptiveGridOptions(formWidgetConfigurations: []),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -1160,6 +1183,7 @@ void main() {
               ),
             ],
             schema: null,
+            links: {},
           ),
         ),
       );
@@ -1276,6 +1300,7 @@ void main() {
         ),
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -1286,6 +1311,7 @@ void main() {
               ),
             ],
             actions: [action],
+            links: {},
             schema: null,
           ),
         ),
@@ -1426,6 +1452,7 @@ void main() {
         client: apptiveGridClient,
         child: ApptiveGridFormData(
           formData: FormData(
+            id: 'formId',
             title: 'title',
             components: [
               GeolocationFormComponent(
@@ -1436,6 +1463,7 @@ void main() {
               ),
             ],
             actions: [action],
+            links: {},
             schema: null,
           ),
         ),

--- a/packages/apptive_grid_form/test/integer_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/integer_form_widget_test.dart
@@ -8,13 +8,22 @@ import 'common.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FormData(title: 'title', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(
+        id: 'id',
+        links: {},
+        title: 'title',
+        components: [],
+        schema: {},
+      ),
+    );
   });
 
   group('Validation', () {
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           IntegerFormComponent(
@@ -25,6 +34,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();

--- a/packages/apptive_grid_form/test/multi_cross_reference_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/multi_cross_reference_form_widget_test.dart
@@ -11,7 +11,15 @@ import 'common.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FormData(title: 'title', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(
+        id: 'id',
+        links: {},
+        title: 'title',
+        components: [],
+        schema: {},
+      ),
+    );
     registerFallbackValue(GridUri(user: 'user', space: 'space', grid: 'grid'));
   });
 
@@ -234,6 +242,7 @@ void main() {
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           MultiCrossReferenceFormComponent(
@@ -258,6 +267,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();

--- a/packages/apptive_grid_form/test/multi_cross_reference_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/multi_cross_reference_form_widget_test.dart
@@ -23,6 +23,7 @@ void main() {
     final gridUri = GridUri(user: 'user', space: 'space', grid: 'grid');
     final field = GridField('field', 'Name', DataType.text);
     final grid = Grid(
+      id: 'grid',
       name: 'Test',
       schema: null,
       fields: [field],
@@ -30,6 +31,13 @@ void main() {
         GridRow('row1', [GridEntry(field, StringDataEntity('First'))]),
         GridRow('row2', [GridEntry(field, StringDataEntity('Second'))]),
       ],
+      links: {
+        ApptiveLinkType.self: ApptiveLink(uri: gridUri.uri, method: 'get'),
+        ApptiveLinkType.entities: ApptiveLink(
+          uri: gridUri.uri.replace(path: '${gridUri.uri.path}/entities'),
+          method: 'get',
+        ),
+      },
     );
 
     setUp(() {
@@ -189,12 +197,20 @@ void main() {
 
     testWidgets('Empty null values', (tester) async {
       final gridWithNull = Grid(
+        id: 'grid',
         name: 'Test',
         schema: null,
         fields: [field],
         rows: [
           GridRow('row1', [GridEntry(field, StringDataEntity())]),
         ],
+        links: {
+          ApptiveLinkType.self: ApptiveLink(uri: gridUri.uri, method: 'get'),
+          ApptiveLinkType.entities: ApptiveLink(
+            uri: gridUri.uri.replace(path: '${gridUri.uri.path}/entities'),
+            method: 'get',
+          ),
+        },
       );
 
       when(() => client.loadGrid(gridUri: gridUri))
@@ -246,8 +262,14 @@ void main() {
       );
       final client = MockApptiveGridClient();
       when(() => client.loadGrid(gridUri: any(named: 'gridUri'))).thenAnswer(
-        (invocation) async =>
-            Grid(name: 'name', schema: {}, fields: [], rows: []),
+        (invocation) async => Grid(
+          id: 'grid',
+          name: 'name',
+          schema: {},
+          fields: [],
+          rows: [],
+          links: {},
+        ),
       );
       when(() => client.sendPendingActions()).thenAnswer((_) => Future.value());
       when(() => client.performAction(action, any()))

--- a/packages/apptive_grid_form/test/single_select_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/single_select_form_widget_test.dart
@@ -8,13 +8,22 @@ import 'common.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FormData(title: 'title', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(
+        id: 'id',
+        links: {},
+        title: 'title',
+        components: [],
+        schema: {},
+      ),
+    );
   });
 
   group('Validation', () {
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           EnumFormComponent(
@@ -25,6 +34,7 @@ void main() {
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();

--- a/packages/apptive_grid_form/test/text_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/text_form_widget_test.dart
@@ -8,7 +8,15 @@ import 'common.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FormData(title: 'title', components: [], schema: {}));
+    registerFallbackValue(
+      FormData(
+        id: 'id',
+        links: {},
+        title: 'title',
+        components: [],
+        schema: {},
+      ),
+    );
   });
 
   testWidgets('Multiline TextFormWidget Displays', (tester) async {
@@ -44,6 +52,7 @@ string''';
 multi-line
 string''';
     final formData = FormData(
+      id: 'formId',
       title: 'Title',
       components: [
         StringFormComponent(
@@ -58,6 +67,7 @@ string''';
         ),
       ],
       schema: null,
+      links: {},
     );
 
     final target = ApptiveGridFormData(
@@ -78,6 +88,7 @@ string''';
     testWidgets('is required but filled sends', (tester) async {
       final action = FormAction('formAction', 'POST');
       final formData = FormData(
+        id: 'formId',
         title: 'title',
         components: [
           StringFormComponent(
@@ -88,6 +99,7 @@ string''';
           )
         ],
         actions: [action],
+        links: {},
         schema: null,
       );
       final client = MockApptiveGridClient();

--- a/packages/apptive_grid_grid_builder/CHANGELOG.md
+++ b/packages/apptive_grid_grid_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0-alpha.1
+* Update Core package
+* Includes a lot of breaking changes in the model including in `Grid`
+
 ## 0.8.1+1
 * Reload builder when uri changed
 

--- a/packages/apptive_grid_grid_builder/example/lib/contact_list.dart
+++ b/packages/apptive_grid_grid_builder/example/lib/contact_list.dart
@@ -80,12 +80,12 @@ class _MyHomePageState extends State<_MyHomePage> {
                 return _builderKey.currentState?.reload() ?? Future.value();
               },
               child: ListView.separated(
-                itemCount: snapshot.data!.rows.length,
+                itemCount: snapshot.data!.rows?.length ?? 0,
                 separatorBuilder: (context, index) {
                   return Divider();
                 },
                 itemBuilder: (context, index) {
-                  final row = snapshot.data!.rows[index];
+                  final row = snapshot.data!.rows![index];
                   return ListTile(
                     leading: Padding(
                       padding: const EdgeInsets.fromLTRB(4, 4, 4, 8),

--- a/packages/apptive_grid_grid_builder/example/lib/main.dart
+++ b/packages/apptive_grid_grid_builder/example/lib/main.dart
@@ -103,16 +103,16 @@ class _MyHomePageState extends State<_MyHomePage> {
             if (_sorting == null) {
               WidgetsBinding.instance?.addPostFrameCallback((_) {
                 late final ApptiveGridSorting newSorting;
-                if (snapshot.data!.fields.first.type == DataType.geolocation) {
+                if (snapshot.data!.fields?.first.type == DataType.geolocation) {
                   newSorting = DistanceApptiveGridSorting(
-                    fieldId: snapshot.data!.fields.first.id,
+                    fieldId: snapshot.data!.fields!.first.id,
                     order: _order,
                     location:
                         Geolocation(latitude: 50.938757, longitude: 6.954399),
                   );
                 } else {
                   newSorting = ApptiveGridSorting(
-                    fieldId: snapshot.data!.fields.first.id,
+                    fieldId: snapshot.data!.fields!.first.id,
                     order: _order,
                   );
                 }
@@ -126,12 +126,12 @@ class _MyHomePageState extends State<_MyHomePage> {
                 return _builderKey.currentState?.reload() ?? Future.value();
               },
               child: ListView.separated(
-                itemCount: snapshot.data!.rows.length,
+                itemCount: snapshot.data!.rows?.length ?? 0,
                 separatorBuilder: (context, index) {
                   return Divider();
                 },
                 itemBuilder: (context, index) {
-                  final row = snapshot.data!.rows[index];
+                  final row = snapshot.data!.rows![index];
                   return ListTile(
                     title: Text(row.entries[1].data.schemaValue),
                     subtitle: Text(row.entries[0].data.value.toString()),

--- a/packages/apptive_grid_grid_builder/pubspec.yaml
+++ b/packages/apptive_grid_grid_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_grid_builder
 description: A Flutter Package to build Widgets based on Data from an ApptiveGrid Grid.
-version: 0.8.1+1
+version: 0.9.0-alpha.1
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_grid_builder
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  apptive_grid_core: ^0.9.0
+  apptive_grid_core: ^0.10.0-alpha.1
   flutter:
     sdk: flutter
 

--- a/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
+++ b/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
@@ -51,10 +51,12 @@ void main() {
       ),
     ).thenAnswer(
       (_) async => Grid(
+        id: gridId,
         name: title,
         schema: null,
         fields: [],
         rows: [],
+        links: {},
       ),
     );
 
@@ -74,10 +76,12 @@ void main() {
           grid: gridId,
         ),
         initialData: Grid(
+          id: gridId,
           name: 'Initial Title',
           schema: null,
           fields: [],
           rows: [],
+          links: {},
         ),
         builder: (context, snapshot) {
           if (snapshot.hasData) {
@@ -96,10 +100,12 @@ void main() {
       ),
     ).thenAnswer(
       (_) async => Grid(
+        id: gridId,
         name: title,
         schema: null,
         fields: [],
         rows: [],
+        links: {},
       ),
     );
 
@@ -170,10 +176,12 @@ void main() {
       ),
     ).thenAnswer(
       (_) async => Grid(
+        id: gridId,
         name: title,
         schema: null,
         fields: [],
         rows: [],
+        links: {},
       ),
     );
 
@@ -209,10 +217,12 @@ void main() {
         ),
       ).thenAnswer(
         (_) async => Grid(
+          id: 'grid',
           name: title,
           schema: null,
           fields: [],
           rows: [],
+          links: {},
         ),
       );
 
@@ -269,10 +279,12 @@ void main() {
         ),
       ).thenAnswer(
         (_) async => Grid(
+          id: 'grid',
           name: title,
           schema: null,
           fields: [],
           rows: [],
+          links: {},
         ),
       );
 
@@ -310,10 +322,12 @@ void main() {
         ),
       ).thenAnswer(
         (_) async => Grid(
+          id: 'grid',
           name: title,
           schema: null,
           fields: [],
           rows: [],
+          links: {},
         ),
       );
 
@@ -362,10 +376,12 @@ void main() {
         ),
       ).thenAnswer(
         (_) async => Grid(
+          id: 'grid',
           name: title,
           schema: null,
           fields: [],
           rows: [],
+          links: {},
         ),
       );
 
@@ -402,10 +418,12 @@ void main() {
         ),
       ).thenAnswer(
         (_) async => Grid(
+          id: 'grid',
           name: title,
           schema: null,
           fields: [],
           rows: [],
+          links: {},
         ),
       );
 

--- a/packages/apptive_grid_web_apptive/CHANGELOG.md
+++ b/packages/apptive_grid_web_apptive/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3-alpha.1
+* Update Core Package.
+* Includes Breaking Changes in the Model
+
 ## 0.0.2
 * Update Packages
 

--- a/packages/apptive_grid_web_apptive/example/lib/apptive_grid_pie_chart.dart
+++ b/packages/apptive_grid_web_apptive/example/lib/apptive_grid_pie_chart.dart
@@ -27,8 +27,9 @@ class _ApptiveGridPieChartState extends State<ApptiveGridPieChart> {
 
   void _setUp() {
     final enumFields = widget.grid.fields
-        .where((element) => element.type == DataType.singleSelect)
-        .toList();
+            ?.where((element) => element.type == DataType.singleSelect)
+            .toList() ??
+        [];
     if (enumFields.isNotEmpty) {
       _isValid = true;
       _needsSelection = enumFields.length > 1;
@@ -44,12 +45,12 @@ class _ApptiveGridPieChartState extends State<ApptiveGridPieChart> {
   void didUpdateWidget(covariant ApptiveGridPieChart oldWidget) {
     super.didUpdateWidget(oldWidget);
     setState(() {
-      final newFieldIds = widget.grid.fields.map((e) => e.id);
-      if (newFieldIds.contains(_field?.id)) {
-        _field = widget.grid.fields
+      final newFieldIds = widget.grid.fields?.map((e) => e.id);
+      if ((newFieldIds ?? []).contains(_field?.id)) {
+        _field = widget.grid.fields!
             .firstWhere((element) => element.id == _field?.id);
       } else {
-        if (_field != null && !newFieldIds.contains(_field?.id)) {
+        if (_field != null && !(newFieldIds ?? []).contains(_field?.id)) {
           _field = null;
         }
         _setUp();
@@ -114,7 +115,7 @@ class _ApptiveGridPieChartState extends State<ApptiveGridPieChart> {
   Map<String, double> _calculateDataMap() {
     final rows = widget.grid.rows;
 
-    final enumValues = (rows[0]
+    final enumValues = (rows?[0]
             .entries
             .firstWhere((element) => element.field.id == _field?.id)
             .data as EnumDataEntity)
@@ -124,7 +125,7 @@ class _ApptiveGridPieChartState extends State<ApptiveGridPieChart> {
       enumValues.map(
         (value) => MapEntry(
           value,
-          rows
+          (rows ?? [])
               .where(
                 (row) =>
                     (row.entries
@@ -187,7 +188,7 @@ class _FieldSelectorState extends State<FieldSelector> {
             autovalidateMode: AutovalidateMode.always,
             onChanged: widget.onSelected,
             items: widget.grid.fields
-                .where(widget.validator)
+                ?.where(widget.validator)
                 .map<DropdownMenuItem<GridField>>(
                   (e) => DropdownMenuItem<GridField>(
                     value: e,

--- a/packages/apptive_grid_web_apptive/pubspec.yaml
+++ b/packages/apptive_grid_web_apptive/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_web_apptive
 description: A Flutter Package to enable Flutter Apptives on ApptiveGrid Web Client
-version: 0.0.2
+version: 0.0.3-alpha.1
 homepage: https://apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_web_apptive
 publish_to: none
@@ -10,7 +10,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  apptive_grid_core: ^0.6.0
+  apptive_grid_core: ^0.10.0-alpha.1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
This turned out a way bigger change than expected as the models have actually quite changed a bit since creation. Short overview:

`Users`, `Spaces`, `Grids` and `Forms` now include Hal Links and embedded things (Spaces in Grids, Grids in Spaces and Forms in Grids)
Due to the format of the embedded objects a lot of arguments in Grids and Forms are now nullable. I thought about having separate Objects for that but I think having one object with nullable fields while being bad for migration is way nicer in the long run. I guess that is a pro that the libraries are still in preview and not fixed.


I was able to add some more tests so that the core package is a bit closer to 100% coverage as well