### PR TITLE
Ac 1813 layout changes

### DIFF
--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed unauthorized retry for performing an ApptiveLink
 * Added custom header to calls where it was missing
 * Added support for all `ApptiveGridLayout` layouts
+* Add parameter `loadEntities` to `loadGrid` to enable not loading entities for the Grid to only get the GridFields and Grid Meta Data
 ### Breaking Change
 * `layout` in `loadEntities` is now `ApptiveGridLayout` instead of `String?`
 

--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Fixed parsing for `key`s in GridField
 * Fixed unauthorized retry for performing an ApptiveLink
 * Added custom header to calls where it was missing
+* Added support for all `ApptiveGridLayout` layouts
+### Breaking Change
+* `layout` in `loadEntities` is now `ApptiveGridLayout` instead of `String?`
 
 ## 0.10.0-alpha.4
 * Adjust GridField to include `key` and `schema`

--- a/packages/apptive_grid_core/lib/apptive_grid_network.dart
+++ b/packages/apptive_grid_core/lib/apptive_grid_network.dart
@@ -21,6 +21,7 @@ export 'package:apptive_grid_core/network/sorting/apptive_grid_sorting.dart';
 
 export 'network/apptive_grid_client.dart';
 
+part 'network/apptive_grid_layout.dart';
 part 'network/authentication/apptive_grid_authentication_options.dart';
 part 'network/authentication/apptive_grid_authenticator.dart';
 part 'network/constants.dart';

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -220,6 +220,7 @@ class ApptiveGridClient {
   /// The order of [ApptiveGridSorting] in [sorting] will rank the order in which values should be sorted
   /// [headers] will be added in addition to [ApptiveGridClient.defaultHeaders]
   ///
+  /// If [loadEntities] is `true` and there is a [ApptiveLinkType.entities] Link it will also fetch the entities
   /// Requires Authorization
   /// throws [Response] if the request fails
   Future<Grid> loadGrid({
@@ -228,6 +229,7 @@ class ApptiveGridClient {
     ApptiveGridFilter? filter,
     bool isRetry = false,
     Map<String, String> headers = const {},
+    bool loadEntities = true,
   }) async {
     final gridViewUrl = _generateApptiveGridUri(gridUri.uri);
 
@@ -250,8 +252,8 @@ class ApptiveGridClient {
 
     final gridToParse = jsonDecode(gridViewResponse.body);
     final grid = Grid.fromJson(gridToParse);
-    if (grid.links.containsKey(ApptiveLinkType.entities)) {
-      final entitiesResponse = await loadEntities(
+    if (loadEntities && grid.links.containsKey(ApptiveLinkType.entities)) {
+      final entitiesResponse = await this.loadEntities(
         uri: grid.links[ApptiveLinkType.entities]!.uri,
         layout: ApptiveGridLayout.indexed,
         filter: filter,

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -253,7 +253,7 @@ class ApptiveGridClient {
     if (grid.links.containsKey(ApptiveLinkType.entities)) {
       final entitiesResponse = await loadEntities(
         uri: grid.links[ApptiveLinkType.entities]!.uri,
-        layout: 'indexed',
+        layout: ApptiveGridLayout.indexed,
         filter: filter,
         sorting: sorting,
       );
@@ -270,26 +270,12 @@ class ApptiveGridClient {
   /// Load Entities of a Grid that are accessed by [uri]
   /// [viewId] specifies allows to request the entities of a specific GridView which allows for getting Filters/Sorting that was applied from the web client
   ///
-  /// if [layout] is not set the items will be a Map<String, dynamic> with the keys being the fieldIds and the value being the values as json objects
-  /// `indexed` layout will return the items in the following format:
-  /// ```
-  /// {
-  ///   "fields": [
-  ///     `jsonValue of First Column`,
-  ///     `jsonValue of Second Column`,
-  ///     `jsonValue of Third Column`,
-  ///     `jsonValue of Fourth Column`,
-  ///     ...
-  ///   ]
-  /// }
-  /// ```
-  ///
   /// [sorting] allows to apply custom sorting
   /// [filter] allows to get custom filters
   /// [headers] will be added in addition to [ApptiveGridClient.defaultHeaders]
   Future<EntitiesResponse<T>> loadEntities<T>({
     required Uri uri,
-    String? layout,
+    ApptiveGridLayout layout = ApptiveGridLayout.field,
     List<ApptiveGridSorting>? sorting,
     ApptiveGridFilter? filter,
     bool isRetry = false,
@@ -299,14 +285,14 @@ class ApptiveGridClient {
     final requestUri = uri.replace(
       scheme: baseUrl.scheme,
       host: baseUrl.host,
-      queryParameters: Map.from(uri.queryParameters)
-        ..addAll({
-          if (layout != null) 'layout': layout,
-          if (sorting != null)
-            'sorting':
-                jsonEncode(sorting.map((e) => e.toRequestObject()).toList()),
-          if (filter != null) 'filter': jsonEncode(filter.toJson()),
-        }),
+      queryParameters: {
+        ...uri.queryParameters,
+        'layout': layout.queryParameter,
+        if (sorting != null)
+          'sorting':
+              jsonEncode(sorting.map((e) => e.toRequestObject()).toList()),
+        if (filter != null) 'filter': jsonEncode(filter.toJson()),
+      },
     );
 
     final response = await _client.get(
@@ -476,13 +462,18 @@ class ApptiveGridClient {
   Future<Map<String, dynamic>> getEntity({
     required EntityUri entityUri,
     Map<String, String> headers = const {},
+    ApptiveGridLayout layout = ApptiveGridLayout.field,
   }) async {
     await _authenticator.checkAuthentication();
 
     final url = _generateApptiveGridUri(entityUri.uri);
 
     final response = await _client.get(
-      url,
+      url.replace(
+        queryParameters: {
+          'layout': layout.queryParameter,
+        },
+      ),
       headers: _createHeadersWithDefaults(headers),
     );
 

--- a/packages/apptive_grid_core/lib/network/apptive_grid_layout.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_layout.dart
@@ -1,0 +1,30 @@
+part of apptive_grid_network;
+
+/// Defines the Layout of an Entity that is returned by ApptiveGrid
+///
+/// When using this manually for example when calling [ApptiveGridClient.performApptiveLink] add this to `queryParamters` as
+/// ```dart
+/// 'layout': ApptiveGridLayout.field.queryParameter,
+/// ```
+enum ApptiveGridLayout {
+  /// This is the layout that returns a JSON where the JSON keys are the field ids
+  field(queryParameter: 'field'),
+
+  /// This is the layout that returns a JSON array containing all fields
+  indexed(queryParameter: 'indexed'),
+
+  /// This is the layout the returns a JSON where the JSON keys are the name of the fields
+  property(queryParameter: 'property'),
+
+  /// This is the layout that returns a JSON where the JSON keys are the key of a field.
+  key(queryParameter: 'key'),
+
+  /// This is the layout that returns a JSON where the JSON keys are either field id or field key. When a field has a key this is used if not the field id which is always present
+  keyAndField(queryParameter: 'keyAndField');
+
+  /// Creates a new ApptiveGrid Layout enum Entry
+  const ApptiveGridLayout({required this.queryParameter});
+
+  /// The query Parameter that should be used when adding this to a request to ApptiveGrid
+  final String queryParameter;
+}

--- a/packages/apptive_grid_core/test/api_client_test.dart
+++ b/packages/apptive_grid_core/test/api_client_test.dart
@@ -432,6 +432,57 @@ void main() {
         ),
       ).called(2);
     });
+
+    test('Do not load entities', () async {
+      reset(httpClient);
+      const user = 'userId';
+      const space = 'spaceId';
+      const gridId = 'gridId';
+
+      final response = Response(json.encode(rawResponse), 200);
+
+      when(
+        () => httpClient.get(
+          Uri.parse(
+            '${ApptiveGridEnvironment.production.url}/api/users/$user/spaces/$space/grids/$gridId',
+          ),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer((_) async => response);
+
+      when(
+        () => httpClient.get(
+          Uri.parse(
+            '${ApptiveGridEnvironment.production.url}/api/users/$user/spaces/$space/grids/$gridId/entities?layout=indexed',
+          ),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer(
+        (_) async => Response(
+          jsonEncode(rawResponse['entities']),
+          200,
+        ),
+      );
+
+      final grid = await apptiveGridClient.loadGrid(
+        gridUri: GridUri(
+          user: user,
+          space: space,
+          grid: gridId,
+        ),
+        loadEntities: false,
+      );
+
+      expect(grid, isNot(null));
+      verifyNever(
+        () => httpClient.get(
+          Uri.parse(
+            '${ApptiveGridEnvironment.production.url}/api/users/$user/spaces/$space/grids/$gridId/entities?layout=indexed',
+          ),
+          headers: any(named: 'headers'),
+        ),
+      );
+    });
   });
 
   group('submitForm', () {


### PR DESCRIPTION
Added the new layouts as a enum and added support in the getEntity and loadEntities calls.

Also as discussed with @soeren-schmaljohann-2denker I added a parameter to load grid to skip loading entities there.

Bonus thanks to @bocasti for writing a great ticket from where I was able to get the documentation perfectly for all the layouts