### PR TITLE
Ac 1870 deprecate apptive grid uri

### DIFF
--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.0-alpha.6
+* Deprecate all `ApptiveLink` in favor of plain `Uri`
+
 ## 0.10.0-alpha.5
 * Add `description` to forms
 * Fixed parsing for `key`s in GridField

--- a/packages/apptive_grid_core/example/lib/main.dart
+++ b/packages/apptive_grid_core/example/lib/main.dart
@@ -50,7 +50,7 @@ class _MyAppState extends State<MyApp> {
                   ),
                 ...((_user?.embeddedSpaces) ?? []).map(
                   (e) => _SpaceSection(
-                    spaceUri: SpaceUri.fromUri(
+                    uri: Uri.parse(
                       e.links[ApptiveLinkType.self]!.uri.toString(),
                     ),
                   ),
@@ -145,10 +145,10 @@ class _UserSectionState extends State<_UserSection> {
 class _SpaceSection extends StatefulWidget {
   const _SpaceSection({
     Key? key,
-    required this.spaceUri,
+    required this.uri,
   }) : super(key: key);
 
-  final SpaceUri spaceUri;
+  final Uri uri;
 
   @override
   State<_SpaceSection> createState() => _SpaceSectionState();
@@ -161,7 +161,7 @@ class _SpaceSectionState extends State<_SpaceSection> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     _spaceFuture = ApptiveGrid.getClient(context).getSpace(
-      spaceUri: widget.spaceUri,
+      uri: widget.uri,
     );
   }
 
@@ -182,7 +182,7 @@ class _SpaceSectionState extends State<_SpaceSection> {
                       children: space.embeddedGrids
                               ?.map(
                                 (e) => _GridSection(
-                                  gridUri: GridUri.fromUri(
+                                  uri: Uri.parse(
                                     e.links[ApptiveLinkType.self]!.uri
                                         .toString(),
                                   ),
@@ -213,10 +213,10 @@ class _SpaceSectionState extends State<_SpaceSection> {
 class _GridSection extends StatefulWidget {
   const _GridSection({
     Key? key,
-    required this.gridUri,
+    required this.uri,
   }) : super(key: key);
 
-  final GridUri gridUri;
+  final Uri uri;
 
   @override
   State<_GridSection> createState() => _GridSectionState();
@@ -229,7 +229,7 @@ class _GridSectionState extends State<_GridSection> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     _gridFuture = ApptiveGrid.getClient(context).loadGrid(
-      gridUri: widget.gridUri,
+      uri: widget.uri,
     );
   }
 

--- a/packages/apptive_grid_core/lib/model/apptive_grid_uri.dart
+++ b/packages/apptive_grid_core/lib/model/apptive_grid_uri.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: deprecated_member_use_from_same_package
+// coverage:ignore-file
 
 part of apptive_grid_model;
 

--- a/packages/apptive_grid_core/lib/model/apptive_grid_uri.dart
+++ b/packages/apptive_grid_core/lib/model/apptive_grid_uri.dart
@@ -1,6 +1,9 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 part of apptive_grid_model;
 
 /// Base class used to represent Objects with a Uri
+@Deprecated('Use a normal `Uri` instead')
 abstract class ApptiveGridUri {
   ApptiveGridUri._(Uri uri, this.type) : _uri = uri;
 
@@ -33,6 +36,7 @@ abstract class ApptiveGridUri {
 }
 
 /// The type that a [ApptiveGridUri] is pointing to
+@Deprecated('Use a normal `Uri` instead')
 enum UriType {
   /// An unknown type. This should normally not occur
   unknown,

--- a/packages/apptive_grid_core/lib/model/data_entity.dart
+++ b/packages/apptive_grid_core/lib/model/data_entity.dart
@@ -204,24 +204,23 @@ class CrossReferenceDataEntity extends DataEntity<String, dynamic> {
   }) =>
       CrossReferenceDataEntity(
         value: jsonValue?['displayValue'],
-        entityUri: jsonValue?['uri'] != null
-            ? EntityUri.fromUri(jsonValue?['uri'])
-            : null,
-        gridUri: GridUri.fromUri(gridUri),
+        entityUri:
+            jsonValue?['uri'] != null ? Uri.parse(jsonValue?['uri']) : null,
+        gridUri: Uri.parse(gridUri),
       );
 
-  /// The [EntityUri] pointing to the Entity this is referencing
-  EntityUri? entityUri;
+  /// The [Uri] pointing to the Entity this is referencing
+  Uri? entityUri;
 
   /// Pointing to the [Grid] this is referencing
-  final GridUri gridUri;
+  final Uri gridUri;
 
   @override
   dynamic get schemaValue {
     if (entityUri == null) {
       return null;
     } else {
-      return {'displayValue': value ?? '', 'uri': entityUri!.uri.toString()};
+      return {'displayValue': value ?? '', 'uri': entityUri!.toString()};
     }
   }
 
@@ -328,12 +327,12 @@ class MultiCrossReferenceDataEntity
               )
               .toList() ??
           [],
-      gridUri: GridUri.fromUri(gridUri),
+      gridUri: Uri.parse(gridUri),
     );
   }
 
   /// Pointing to the [Grid] this is referencing
-  final GridUri gridUri;
+  final Uri gridUri;
 
   @override
   dynamic get schemaValue {

--- a/packages/apptive_grid_core/lib/model/entity/entity_uri.dart
+++ b/packages/apptive_grid_core/lib/model/entity/entity_uri.dart
@@ -1,6 +1,7 @@
 part of apptive_grid_model;
 
 /// A Uri representation used for performing Grid based Api Calls
+@Deprecated('Use a normal `Uri` instead')
 class EntityUri extends ApptiveGridUri {
   /// Creates a new [EntityUri] based on known ids for [user], [space] and [grid]
   EntityUri({

--- a/packages/apptive_grid_core/lib/model/form/form_uri.dart
+++ b/packages/apptive_grid_core/lib/model/form/form_uri.dart
@@ -10,6 +10,7 @@ part of apptive_grid_model;
 ///
 /// [RedirectFormUri] should be used if you accessed a Form via a Redirect Link e.g. https://app.apptivegrid.de/api/r/609bd6f89fcca3c4c77e70fa
 /// [DirectFormUri] should be used if accessed
+@Deprecated('Use a normal `Uri` instead')
 class FormUri extends ApptiveGridUri {
   FormUri._(Uri uri)
       : super._(
@@ -34,6 +35,7 @@ class FormUri extends ApptiveGridUri {
 }
 
 /// A FormUri for a Form represented by a redirect Link
+@Deprecated('Use a normal `Uri` instead')
 class RedirectFormUri extends FormUri {
   /// Create a FormUri accessed via a redirect Link from the ApptiveGrid UI Console
   /// for https://app.apptivegrid.de/api/r/609bd6f89fcca3c4c77e70fa `609bd6f89fcca3c4c77e70fa` would be [components]
@@ -46,6 +48,7 @@ class RedirectFormUri extends FormUri {
 }
 
 /// A FormUri for a Form represented by a direct Link
+@Deprecated('Use a normal `Uri` instead')
 class DirectFormUri extends FormUri {
   /// Create a FormUri with known attributes for [user], [space], [grid], [form]
   DirectFormUri({

--- a/packages/apptive_grid_core/lib/model/grid/grid.dart
+++ b/packages/apptive_grid_core/lib/model/grid/grid.dart
@@ -1,6 +1,7 @@
 part of apptive_grid_model;
 
 /// A Uri representation used for performing Grid based Api Calls
+@Deprecated('Use a normal `Uri` instead')
 class GridUri extends ApptiveGridUri {
   /// Creates a new [GridUri] based on known ids for [user], [space] and [grid]
   GridUri({

--- a/packages/apptive_grid_core/lib/model/grid/grid_view.dart
+++ b/packages/apptive_grid_core/lib/model/grid/grid_view.dart
@@ -1,6 +1,7 @@
 part of apptive_grid_model;
 
 /// A Uri representing a GridView
+@Deprecated('Use a normal `Uri` instead')
 class GridViewUri extends GridUri {
   /// Creates a new [GridViewUri] based on known ids for [user], [space], [grid] and [view]
   GridViewUri({

--- a/packages/apptive_grid_core/lib/model/space/space.dart
+++ b/packages/apptive_grid_core/lib/model/space/space.dart
@@ -1,6 +1,7 @@
 part of apptive_grid_model;
 
 /// A Uri representation used for performing Space based Api Calls
+@Deprecated('Use a normal `Uri` instead')
 class SpaceUri extends ApptiveGridUri {
   /// Creates a new [SpaceUri] based on known ids for [user] and [space]
   SpaceUri({

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -86,10 +86,7 @@ class ApptiveGridClient {
     Map<String, String> headers = const {},
     bool isRetry = false,
   }) async {
-    assert(
-      uri != null || formUri != null,
-      'Either uri ($uri) or formUri ($formUri) must not be null',
-    );
+    assert(uri != null || formUri != null);
     final url = _generateApptiveGridUri(uri ?? formUri!.uri);
     final response =
         await _client.get(url, headers: _createHeadersWithDefaults(headers));

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -80,11 +80,14 @@ class ApptiveGridClient {
   /// Based on [formUri] this might require Authentication
   /// throws [Response] if the request fails
   Future<FormData> loadForm({
-    required FormUri formUri,
+    // ignore: deprecated_member_use_from_same_package
+    @Deprecated('Use `uri` instead') FormUri? formUri,
+    Uri? uri,
     Map<String, String> headers = const {},
     bool isRetry = false,
   }) async {
-    final url = _generateApptiveGridUri(formUri.uri);
+    assert(uri != null || formUri != null);
+    final url = _generateApptiveGridUri(uri ?? formUri!.uri);
     final response =
         await _client.get(url, headers: _createHeadersWithDefaults(headers));
     if (response.statusCode >= 400) {
@@ -224,14 +227,17 @@ class ApptiveGridClient {
   /// Requires Authorization
   /// throws [Response] if the request fails
   Future<Grid> loadGrid({
-    required GridUri gridUri,
+    // ignore: deprecated_member_use_from_same_package
+    @Deprecated('Use `uri` instead') GridUri? gridUri,
+    Uri? uri,
     List<ApptiveGridSorting>? sorting,
     ApptiveGridFilter? filter,
     bool isRetry = false,
     Map<String, String> headers = const {},
     bool loadEntities = true,
   }) async {
-    final gridViewUrl = _generateApptiveGridUri(gridUri.uri);
+    assert(uri != null || gridUri != null);
+    final gridViewUrl = _generateApptiveGridUri(uri ?? gridUri!.uri);
 
     final gridHeaders = _createHeadersWithDefaults(headers);
     gridHeaders['Accept'] = 'application/vnd.apptivegrid.hal;version=2';
@@ -352,12 +358,15 @@ class ApptiveGridClient {
   /// Requires Authorization
   /// throws [Response] if the request fails
   Future<Space> getSpace({
-    required SpaceUri spaceUri,
+    // ignore: deprecated_member_use_from_same_package
+    @Deprecated('Use `uri` instead') SpaceUri? spaceUri,
+    Uri? uri,
     Map<String, String> headers = const {},
   }) async {
+    assert(uri != null || spaceUri != null);
     await _authenticator.checkAuthentication();
 
-    final url = _generateApptiveGridUri(spaceUri.uri);
+    final url = _generateApptiveGridUri(uri ?? spaceUri!.uri);
     final response =
         await _client.get(url, headers: _createHeadersWithDefaults(headers));
     if (response.statusCode >= 400) {
@@ -372,6 +381,9 @@ class ApptiveGridClient {
   ///
   /// Requires Authorization
   /// throws [Response] if the request fails
+  @Deprecated(
+    'Consider using the `ApptiveLinkType.forms` link of a `Grid` and call `performApptiveLink` instead. This function will be removed in the future',
+  )
   Future<List<FormUri>> getForms({
     required GridUri gridUri,
     Map<String, String> headers = const {},
@@ -399,6 +411,9 @@ class ApptiveGridClient {
   ///
   /// Requires Authorization
   /// throws [Response] if the request fails
+  @Deprecated(
+    'Consider using the `ApptiveLinkType.views` link of a `Grid` and call `performApptiveLink` instead. This function will be removed in the future',
+  )
   Future<List<GridViewUri>> getGridViews({
     required GridUri gridUri,
     Map<String, String> headers = const {},
@@ -420,23 +435,24 @@ class ApptiveGridClient {
         .toList();
   }
 
-  /// Creates and returns a [FormUri] filled with the Data represented by [entityUri]
+  /// Creates and returns a [Uri] pointing to a Form filled with the Data represented for a given entitiy
   ///
   /// [headers] will be added in addition to [ApptiveGridClient.defaultHeaders]
   ///
   /// Requires Authorization
   /// throws [Response] if the request fails
-  Future<FormUri> getEditLink({
-    required EntityUri entityUri,
+  Future<Uri> getEditLink({
+    @Deprecated('Use `uri` instead. This Uri should be taken from the `ApptiveLinkType.addEditionLink`')
+        // ignore: deprecated_member_use_from_same_package
+        EntityUri? entityUri,
+    Uri? uri,
     required String formId,
     Map<String, String> headers = const {},
   }) async {
+    assert(uri != null || entityUri != null);
     await _authenticator.checkAuthentication();
 
-    final baseUrl = _generateApptiveGridUri(entityUri.uri);
-    final url = baseUrl.replace(
-      pathSegments: [...baseUrl.pathSegments, 'EditLink'],
-    );
+    final url = _generateApptiveGridUri(uri ?? entityUri!.uri);
 
     final response = await _client.post(
       url,
@@ -450,10 +466,10 @@ class ApptiveGridClient {
       throw response;
     }
 
-    return FormUri.fromUri((json.decode(response.body) as Map)['uri']);
+    return Uri.parse((json.decode(response.body) as Map)['uri']);
   }
 
-  /// Get a specific entity via a [entityUri]
+  /// Get a specific entity via a [uri]
   ///
   /// [headers] will be added in addition to [ApptiveGridClient.defaultHeaders]
   ///
@@ -462,14 +478,17 @@ class ApptiveGridClient {
   ///
   /// The entity will be layed out according to [layout]
   /// The id of the entity can be accessed via `['_id']`
-  Future<Map<String, dynamic>> getEntity({
-    required EntityUri entityUri,
+  Future<dynamic> getEntity({
+    // ignore: deprecated_member_use_from_same_package
+    @Deprecated('Use `uri` instead') EntityUri? entityUri,
+    Uri? uri,
     Map<String, String> headers = const {},
     ApptiveGridLayout layout = ApptiveGridLayout.field,
   }) async {
+    assert(uri != null || entityUri != null);
     await _authenticator.checkAuthentication();
 
-    final url = _generateApptiveGridUri(entityUri.uri);
+    final url = _generateApptiveGridUri(uri ?? entityUri!.uri);
 
     final response = await _client.get(
       url.replace(

--- a/packages/apptive_grid_core/pubspec.yaml
+++ b/packages/apptive_grid_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_core
 description: Core Library for ApptiveGrid used to provide general ApptiveGrid functionality to other Packages or Apps
-version: 0.10.0-alpha.5
+version: 0.10.0-alpha.6
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_core
 

--- a/packages/apptive_grid_core/test/api_client_test.dart
+++ b/packages/apptive_grid_core/test/api_client_test.dart
@@ -118,7 +118,7 @@ void main() {
           .thenAnswer((_) async => response);
 
       final formData = await apptiveGridClient.loadForm(
-        formUri: RedirectFormUri(components: ['FormId']),
+        uri: Uri.parse('/api/a/FormId'),
       );
 
       expect(formData.title, equals('Form'));
@@ -150,12 +150,8 @@ void main() {
           .thenAnswer((_) => Future.value());
 
       await client.loadForm(
-        formUri: DirectFormUri(
-          user: 'user',
-          space: 'space',
-          grid: 'grid',
-          form: 'FormId',
-        ),
+        uri:
+            Uri.parse('/api/a/users/user/spaces/space/grids/grid/forms/FormId'),
       );
       verify(() => authenticator.checkAuthentication()).called(1);
     });
@@ -178,11 +174,8 @@ void main() {
 
       try {
         await client.loadForm(
-          formUri: DirectFormUri(
-            user: 'user',
-            space: 'space',
-            grid: 'grid',
-            form: 'FormId',
+          uri: Uri.parse(
+            '/api/a/users/user/spaces/space/grids/grid/forms/FormId',
           ),
         );
       } catch (error) {
@@ -199,7 +192,7 @@ void main() {
 
       expect(
         () => apptiveGridClient.loadForm(
-          formUri: RedirectFormUri(components: ['FormId']),
+          uri: Uri.parse('/api/a/FormId'),
         ),
         throwsA(isInstanceOf<Response>()),
       );
@@ -350,11 +343,7 @@ void main() {
       );
 
       final grid = await apptiveGridClient.loadGrid(
-        gridUri: GridUri(
-          user: user,
-          space: space,
-          grid: gridId,
-        ),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
       );
 
       expect(grid, isNot(null));
@@ -378,7 +367,7 @@ void main() {
 
       expect(
         () => apptiveGridClient.loadGrid(
-          gridUri: GridUri(user: user, space: space, grid: gridId),
+          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
         ),
         throwsA(isInstanceOf<Response>()),
       );
@@ -393,12 +382,12 @@ void main() {
       final retryResponse = Response(json.encode(rawResponse), 200);
       bool isRetry = false;
 
-      final uri = GridUri.fromUri(
+      final uri = Uri.parse(
         '${ApptiveGridEnvironment.production.url}/api/users/$user/spaces/$space/grids/$gridId',
       );
       when(
         () => httpClient.get(
-          any(that: predicate<Uri>((testUri) => testUri.path == uri.uri.path)),
+          any(that: predicate<Uri>((testUri) => testUri.path == uri.path)),
           headers: any(named: 'headers'),
         ),
       ).thenAnswer((_) async {
@@ -423,11 +412,11 @@ void main() {
         ),
       );
 
-      await apptiveGridClient.loadGrid(gridUri: uri);
+      await apptiveGridClient.loadGrid(uri: uri);
 
       verify(
         () => httpClient.get(
-          any(that: predicate<Uri>((testUri) => testUri.path == uri.uri.path)),
+          any(that: predicate<Uri>((testUri) => testUri.path == uri.path)),
           headers: any(named: 'headers'),
         ),
       ).called(2);
@@ -465,11 +454,7 @@ void main() {
       );
 
       final grid = await apptiveGridClient.loadGrid(
-        gridUri: GridUri(
-          user: user,
-          space: space,
-          grid: gridId,
-        ),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
         loadEntities: false,
       );
 
@@ -1591,15 +1576,12 @@ void main() {
         () => authenticator.checkAuthentication(),
       ).thenAnswer((invocation) async {});
 
-      final mockEntityUri = EntityUri(
-        user: 'user',
-        space: 'space',
-        grid: 'grid',
-        entity: 'entity',
+      final mockEntityUri = Uri.parse(
+        '/api/a/users/user/spaces/space/grids/grid/entities/entity',
       );
 
       final uri = Uri.parse(
-        '${ApptiveGridEnvironment.production.url}${mockEntityUri.uri.toString()}?layout=property',
+        '${ApptiveGridEnvironment.production.url}${mockEntityUri.toString()}?layout=property',
       );
 
       when(
@@ -1617,7 +1599,7 @@ void main() {
       );
 
       await client.getEntity(
-        entityUri: mockEntityUri,
+        uri: mockEntityUri,
         layout: ApptiveGridLayout.property,
         headers: {'custom': 'header'},
       );
@@ -1747,7 +1729,7 @@ void main() {
   group('get Space', () {
     const userId = 'userId';
     const spaceId = 'spaceId';
-    final spaceUri = SpaceUri(user: userId, space: spaceId);
+    final spaceUri = Uri.parse('api/a/users/$userId/spaces/$spaceId');
     final rawResponse = {
       'id': spaceId,
       'name': 'TestSpace',
@@ -1767,7 +1749,7 @@ void main() {
         ),
       ).thenAnswer((_) async => response);
 
-      final space = await apptiveGridClient.getSpace(spaceUri: spaceUri);
+      final space = await apptiveGridClient.getSpace(uri: spaceUri);
 
       expect(space, isNot(null));
     });
@@ -1785,7 +1767,7 @@ void main() {
       ).thenAnswer((_) async => response);
 
       expect(
-        () => apptiveGridClient.getSpace(spaceUri: spaceUri),
+        () => apptiveGridClient.getSpace(uri: spaceUri),
         throwsA(isInstanceOf<Response>()),
       );
     });
@@ -1797,6 +1779,7 @@ void main() {
     const gridId = 'gridId';
     const form0 = 'formId0';
     const form1 = 'formId1';
+    // ignore: deprecated_member_use_from_same_package
     final gridUri = GridUri(user: userId, space: spaceId, grid: gridId);
     final rawResponse = [
       '/api/users/id/spaces/spaceId/grids/gridId/forms/$form0',
@@ -1814,6 +1797,7 @@ void main() {
         ),
       ).thenAnswer((_) async => response);
 
+      // ignore: deprecated_member_use_from_same_package
       final forms = await apptiveGridClient.getForms(gridUri: gridUri);
 
       expect(forms.length, equals(2));
@@ -1840,6 +1824,7 @@ void main() {
       ).thenAnswer((_) async => response);
 
       expect(
+        // ignore: deprecated_member_use_from_same_package
         () => apptiveGridClient.getForms(gridUri: gridUri),
         throwsA(isInstanceOf<Response>()),
       );
@@ -1852,6 +1837,7 @@ void main() {
     const gridId = 'gridId';
     const view0 = 'viewId0';
     const view1 = 'viewId1';
+    // ignore: deprecated_member_use_from_same_package
     final gridUri = GridUri(user: userId, space: spaceId, grid: gridId);
     final rawResponse = [
       '/api/users/id/spaces/spaceId/grids/gridId/views/$view0',
@@ -1869,6 +1855,7 @@ void main() {
         ),
       ).thenAnswer((_) async => response);
 
+      // ignore: deprecated_member_use_from_same_package
       final views = await apptiveGridClient.getGridViews(gridUri: gridUri);
 
       expect(views.length, equals(2));
@@ -1895,6 +1882,7 @@ void main() {
       ).thenAnswer((_) async => response);
 
       expect(
+        // ignore: deprecated_member_use_from_same_package
         () => apptiveGridClient.getGridViews(gridUri: gridUri),
         throwsA(isInstanceOf<Response>()),
       );
@@ -2061,12 +2049,7 @@ void main() {
       });
 
       final gridView = await apptiveGridClient.loadGrid(
-        gridUri: GridViewUri(
-          user: userId,
-          space: spaceId,
-          grid: gridId,
-          view: view0,
-        ),
+        uri: Uri.parse('/api/a/users/$userId/spaces/$spaceId/grids/$view0'),
       );
 
       expect(gridView.filter, isNot(null));
@@ -2233,12 +2216,7 @@ void main() {
             order: SortOrder.desc,
           )
         ],
-        gridUri: GridViewUri(
-          user: userId,
-          space: spaceId,
-          grid: gridId,
-          view: view0,
-        ),
+        uri: Uri.parse('/api/a/users/$userId/spaces/$spaceId/grids/$view0'),
       );
 
       verify(
@@ -2412,12 +2390,7 @@ void main() {
           fieldId: '9fqx8om03flgh8d4m1l953x29',
           value: StringDataEntity('a'),
         ),
-        gridUri: GridViewUri(
-          user: userId,
-          space: spaceId,
-          grid: gridId,
-          view: view0,
-        ),
+        uri: Uri.parse('/api/a/users/$userId/spaces/$spaceId/grids/$view0'),
       );
 
       verify(
@@ -2530,8 +2503,9 @@ void main() {
     const gridId = 'gridId';
     const entityId = 'entityId';
     const form = 'form';
-    final entityUri =
-        EntityUri(user: userId, space: spaceId, grid: gridId, entity: entityId);
+    final entityUri = Uri.parse(
+      '/api/a/users/$userId/spaces/$spaceId/grids/$gridId/entities/$entityId',
+    );
     final rawResponse = {
       'uri': '/api/r/$form',
     };
@@ -2549,11 +2523,11 @@ void main() {
       ).thenAnswer((_) async => response);
 
       final formUri = await apptiveGridClient.getEditLink(
-        entityUri: entityUri,
+        uri: entityUri,
         formId: form,
       );
 
-      expect(formUri.uri, equals(Uri(path: '/api/a/$form')));
+      expect(formUri, equals(Uri(path: '/api/a/$form')));
     });
 
     test('400 Status throws Response', () async {
@@ -2570,7 +2544,7 @@ void main() {
       ).thenAnswer((_) async => response);
 
       expect(
-        () => apptiveGridClient.getEditLink(entityUri: entityUri, formId: form),
+        () => apptiveGridClient.getEditLink(uri: entityUri, formId: form),
         throwsA(isInstanceOf<Response>()),
       );
     });
@@ -2581,8 +2555,9 @@ void main() {
     const spaceId = 'spaceId';
     const gridId = 'gridId';
     const entityId = 'entityId';
-    final entityUri =
-        EntityUri(user: userId, space: spaceId, grid: gridId, entity: entityId);
+    final entityUri = Uri.parse(
+      '/api/a/users/$userId/spaces/$spaceId/grids/$gridId/entities/$entityId',
+    );
     final rawResponse = {
       '4um33znbt8l6x0vzvo0mperwj': null,
       '_id': 'entityId',
@@ -2600,7 +2575,7 @@ void main() {
         ),
       ).thenAnswer((_) async => response);
 
-      final entity = await apptiveGridClient.getEntity(entityUri: entityUri);
+      final entity = await apptiveGridClient.getEntity(uri: entityUri);
 
       expect(entity, equals(rawResponse));
     });
@@ -2618,7 +2593,7 @@ void main() {
       ).thenAnswer((_) async => response);
 
       expect(
-        () => apptiveGridClient.getEntity(entityUri: entityUri),
+        () => apptiveGridClient.getEntity(uri: entityUri),
         throwsA(isInstanceOf<Response>()),
       );
     });
@@ -2636,7 +2611,7 @@ void main() {
       ).thenAnswer((_) async => response);
 
       final entity = await apptiveGridClient.getEntity(
-        entityUri: entityUri,
+        uri: entityUri,
         layout: ApptiveGridLayout.key,
       );
 

--- a/packages/apptive_grid_core/test/api_client_test.dart
+++ b/packages/apptive_grid_core/test/api_client_test.dart
@@ -150,8 +150,7 @@ void main() {
           .thenAnswer((_) => Future.value());
 
       await client.loadForm(
-        uri:
-            Uri.parse('/api/a/users/user/spaces/space/grids/grid/forms/FormId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/grid/forms/FormId'),
       );
       verify(() => authenticator.checkAuthentication()).called(1);
     });
@@ -175,7 +174,7 @@ void main() {
       try {
         await client.loadForm(
           uri: Uri.parse(
-            '/api/a/users/user/spaces/space/grids/grid/forms/FormId',
+            '/api/users/user/spaces/space/grids/grid/forms/FormId',
           ),
         );
       } catch (error) {
@@ -200,6 +199,10 @@ void main() {
   });
 
   group('Load Grid', () {
+    const userId = 'userId';
+    const spaceId = 'spaceId';
+    const gridId = 'gridId';
+
     final rawResponse = {
       'fieldNames': ['First Name', 'Last Name', 'imgUrl'],
       'entities': [
@@ -235,32 +238,33 @@ void main() {
       'id': 'gridId',
       '_links': {
         "addLink": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/AddLink",
           "method": "post"
         },
         "forms": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/forms",
           "method": "get"
         },
         "updateFieldType": {
           "href":
-              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+              "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnTypeChange",
           "method": "post"
         },
         "removeField": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+          "href":
+              "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnRemove",
           "method": "post"
         },
         "addEntity": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/entities",
           "method": "post"
         },
         "views": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/views",
           "method": "get"
         },
         "addView": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/views",
           "method": "post"
         },
         "self": {
@@ -270,39 +274,40 @@ void main() {
         },
         "updateFieldKey": {
           "href":
-              "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+              "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnKeyChange",
           "method": "post"
         },
         "query": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/query",
           "method": "get"
         },
         "entities": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/entities",
           "method": "get"
         },
         "updates": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/updates",
           "method": "get"
         },
         "schema": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/schema",
           "method": "get"
         },
         "updateFieldName": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+          "href":
+              "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnRename",
           "method": "post"
         },
         "addForm": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/forms",
           "method": "post"
         },
         "addField": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnAdd",
           "method": "post"
         },
         "rename": {
-          "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+          "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/Rename",
           "method": "post"
         },
         "remove": {
@@ -313,16 +318,12 @@ void main() {
       },
     };
     test('Success', () async {
-      const user = 'userId';
-      const space = 'spaceId';
-      const gridId = 'gridId';
-
       final response = Response(json.encode(rawResponse), 200);
 
       when(
         () => httpClient.get(
           Uri.parse(
-            '${ApptiveGridEnvironment.production.url}/api/users/$user/spaces/$space/grids/$gridId',
+            '${ApptiveGridEnvironment.production.url}/api/users/$userId/spaces/$spaceId/grids/$gridId',
           ),
           headers: any(named: 'headers'),
         ),
@@ -331,7 +332,7 @@ void main() {
       when(
         () => httpClient.get(
           Uri.parse(
-            '${ApptiveGridEnvironment.production.url}/api/users/$user/spaces/$space/grids/$gridId/entities?layout=indexed',
+            '${ApptiveGridEnvironment.production.url}/api/users/$userId/spaces/$spaceId/grids/$gridId/entities?layout=indexed',
           ),
           headers: any(named: 'headers'),
         ),
@@ -343,7 +344,7 @@ void main() {
       );
 
       final grid = await apptiveGridClient.loadGrid(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/$userId/spaces/$spaceId/grids/$gridId'),
       );
 
       expect(grid, isNot(null));
@@ -367,7 +368,7 @@ void main() {
 
       expect(
         () => apptiveGridClient.loadGrid(
-          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/$user/spaces/$space/grids/$gridId'),
         ),
         throwsA(isInstanceOf<Response>()),
       );
@@ -454,7 +455,7 @@ void main() {
       );
 
       final grid = await apptiveGridClient.loadGrid(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/$user/spaces/$space/grids/$gridId'),
         loadEntities: false,
       );
 
@@ -1577,7 +1578,7 @@ void main() {
       ).thenAnswer((invocation) async {});
 
       final mockEntityUri = Uri.parse(
-        '/api/a/users/user/spaces/space/grids/grid/entities/entity',
+        '/api/users/user/spaces/space/grids/grid/entities/entity',
       );
 
       final uri = Uri.parse(
@@ -1729,7 +1730,7 @@ void main() {
   group('get Space', () {
     const userId = 'userId';
     const spaceId = 'spaceId';
-    final spaceUri = Uri.parse('api/a/users/$userId/spaces/$spaceId');
+    final spaceUri = Uri.parse('api/users/$userId/spaces/$spaceId');
     final rawResponse = {
       'id': spaceId,
       'name': 'TestSpace',
@@ -1840,8 +1841,8 @@ void main() {
     // ignore: deprecated_member_use_from_same_package
     final gridUri = GridUri(user: userId, space: spaceId, grid: gridId);
     final rawResponse = [
-      '/api/users/id/spaces/spaceId/grids/gridId/views/$view0',
-      '/api/users/id/spaces/spaceId/grids/gridId/views/$view1',
+      '/api/users/$userId/spaces/$spaceId/grids/$gridId/views/$view0',
+      '/api/users/$userId/spaces/$spaceId/grids/$gridId/views/$view1',
     ];
     test('Success', () async {
       final response = Response(json.encode(rawResponse), 200);
@@ -1861,11 +1862,11 @@ void main() {
       expect(views.length, equals(2));
       expect(
         views[0].uri.toString(),
-        '/api/users/id/spaces/spaceId/grids/gridId/views/$view0',
+        '/api/users/$userId/spaces/$spaceId/grids/$gridId/views/$view0',
       );
       expect(
         views[1].uri.toString(),
-        '/api/users/id/spaces/spaceId/grids/gridId/views/$view1',
+        '/api/users/$userId/spaces/$spaceId/grids/$gridId/views/$view1',
       );
     });
 
@@ -1948,33 +1949,33 @@ void main() {
         'id': 'gridId',
         '_links': {
           "addLink": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/AddLink",
             "method": "post"
           },
           "forms": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/forms",
             "method": "get"
           },
           "updateFieldType": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnTypeChange",
             "method": "post"
           },
           "removeField": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnRemove",
             "method": "post"
           },
           "addEntity": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/entities",
             "method": "post"
           },
           "views": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/views",
             "method": "get"
           },
           "addView": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/views",
             "method": "post"
           },
           "self": {
@@ -1984,40 +1985,41 @@ void main() {
           },
           "updateFieldKey": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnKeyChange",
             "method": "post"
           },
           "query": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/query",
             "method": "get"
           },
           "entities": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/entities",
             "method": "get"
           },
           "updates": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/updates",
             "method": "get"
           },
           "schema": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/schema",
             "method": "get"
           },
           "updateFieldName": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnRename",
             "method": "post"
           },
           "addForm": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/forms",
             "method": "post"
           },
           "addField": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+            "href":
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnAdd",
             "method": "post"
           },
           "rename": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/Rename",
             "method": "post"
           },
           "remove": {
@@ -2039,7 +2041,7 @@ void main() {
         ),
       ).thenAnswer((invocation) async {
         final uri = invocation.positionalArguments.first as Uri;
-        if (uri.path.endsWith('/views/$view0')) {
+        if (uri.path.endsWith('/grids/$gridId')) {
           return response;
         } else if (uri.path.endsWith('entities')) {
           return Response(json.encode(gridViewResponse['entities']), 200);
@@ -2049,7 +2051,7 @@ void main() {
       });
 
       final gridView = await apptiveGridClient.loadGrid(
-        uri: Uri.parse('/api/a/users/$userId/spaces/$spaceId/grids/$view0'),
+        uri: Uri.parse('/api/users/$userId/spaces/$spaceId/grids/$gridId'),
       );
 
       expect(gridView.filter, isNot(null));
@@ -2096,33 +2098,33 @@ void main() {
         'id': 'gridId',
         '_links': {
           "addLink": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/AddLink",
             "method": "post"
           },
           "forms": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/forms",
             "method": "get"
           },
           "updateFieldType": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnTypeChange",
             "method": "post"
           },
           "removeField": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnRemove",
             "method": "post"
           },
           "addEntity": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/entities",
             "method": "post"
           },
           "views": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/views",
             "method": "get"
           },
           "addView": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/views",
             "method": "post"
           },
           "self": {
@@ -2132,40 +2134,41 @@ void main() {
           },
           "updateFieldKey": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnKeyChange",
             "method": "post"
           },
           "query": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/query",
             "method": "get"
           },
           "entities": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/entities",
             "method": "get"
           },
           "updates": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/updates",
             "method": "get"
           },
           "schema": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/schema",
             "method": "get"
           },
           "updateFieldName": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnRename",
             "method": "post"
           },
           "addForm": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/forms",
             "method": "post"
           },
           "addField": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+            "href":
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnAdd",
             "method": "post"
           },
           "rename": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/Rename",
             "method": "post"
           },
           "remove": {
@@ -2200,7 +2203,7 @@ void main() {
         ),
       ).thenAnswer((invocation) async {
         final uri = invocation.positionalArguments.first as Uri;
-        if (uri.path.endsWith('/views/$view0')) {
+        if (uri.path.endsWith('/grids/$gridId')) {
           return gridViewResponse;
         } else if (uri.path.endsWith('entities')) {
           return gridViewEntitiesResponse;
@@ -2216,7 +2219,7 @@ void main() {
             order: SortOrder.desc,
           )
         ],
-        uri: Uri.parse('/api/a/users/$userId/spaces/$spaceId/grids/$view0'),
+        uri: Uri.parse('/api/users/$userId/spaces/$spaceId/grids/$gridId'),
       );
 
       verify(
@@ -2272,33 +2275,33 @@ void main() {
         'id': 'gridId',
         '_links': {
           "addLink": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/AddLink",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/AddLink",
             "method": "post"
           },
           "forms": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/forms",
             "method": "get"
           },
           "updateFieldType": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnTypeChange",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnTypeChange",
             "method": "post"
           },
           "removeField": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRemove",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnRemove",
             "method": "post"
           },
           "addEntity": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/entities",
             "method": "post"
           },
           "views": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/views",
             "method": "get"
           },
           "addView": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/views",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/views",
             "method": "post"
           },
           "self": {
@@ -2308,40 +2311,41 @@ void main() {
           },
           "updateFieldKey": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnKeyChange",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnKeyChange",
             "method": "post"
           },
           "query": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/query",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/query",
             "method": "get"
           },
           "entities": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/entities",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/entities",
             "method": "get"
           },
           "updates": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/updates",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/updates",
             "method": "get"
           },
           "schema": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/schema",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/schema",
             "method": "get"
           },
           "updateFieldName": {
             "href":
-                "/api/users/userId/spaces/spaceId/grids/gridId/ColumnRename",
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnRename",
             "method": "post"
           },
           "addForm": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/forms",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/forms",
             "method": "post"
           },
           "addField": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/ColumnAdd",
+            "href":
+                "/api/users/$userId/spaces/$spaceId/grids/$gridId/ColumnAdd",
             "method": "post"
           },
           "rename": {
-            "href": "/api/users/userId/spaces/spaceId/grids/gridId/Rename",
+            "href": "/api/users/$userId/spaces/$spaceId/grids/$gridId/Rename",
             "method": "post"
           },
           "remove": {
@@ -2376,7 +2380,7 @@ void main() {
         ),
       ).thenAnswer((invocation) async {
         final uri = invocation.positionalArguments.first as Uri;
-        if (uri.path.endsWith('/views/$view0')) {
+        if (uri.path.endsWith('/grids/$gridId')) {
           return gridViewResponse;
         } else if (uri.path.endsWith('entities')) {
           return gridViewEntitiesResponse;
@@ -2390,7 +2394,7 @@ void main() {
           fieldId: '9fqx8om03flgh8d4m1l953x29',
           value: StringDataEntity('a'),
         ),
-        uri: Uri.parse('/api/a/users/$userId/spaces/$spaceId/grids/$view0'),
+        uri: Uri.parse('/api/users/$userId/spaces/$spaceId/grids/$gridId'),
       );
 
       verify(
@@ -2504,7 +2508,7 @@ void main() {
     const entityId = 'entityId';
     const form = 'form';
     final entityUri = Uri.parse(
-      '/api/a/users/$userId/spaces/$spaceId/grids/$gridId/entities/$entityId',
+      '/api/users/$userId/spaces/$spaceId/grids/$gridId/entities/$entityId',
     );
     final rawResponse = {
       'uri': '/api/r/$form',
@@ -2523,7 +2527,12 @@ void main() {
       ).thenAnswer((_) async => response);
 
       final formUri = await apptiveGridClient.getEditLink(
-        uri: entityUri,
+        uri: entityUri.replace(
+          pathSegments: [
+            ...entityUri.pathSegments,
+            'EditLink',
+          ],
+        ),
         formId: form,
       );
 
@@ -2544,7 +2553,15 @@ void main() {
       ).thenAnswer((_) async => response);
 
       expect(
-        () => apptiveGridClient.getEditLink(uri: entityUri, formId: form),
+        () => apptiveGridClient.getEditLink(
+          uri: entityUri.replace(
+            pathSegments: [
+              ...entityUri.pathSegments,
+              'EditLink',
+            ],
+          ),
+          formId: form,
+        ),
         throwsA(isInstanceOf<Response>()),
       );
     });
@@ -2556,7 +2573,7 @@ void main() {
     const gridId = 'gridId';
     const entityId = 'entityId';
     final entityUri = Uri.parse(
-      '/api/a/users/$userId/spaces/$spaceId/grids/$gridId/entities/$entityId',
+      '/api/users/$userId/spaces/$spaceId/grids/$gridId/entities/$entityId',
     );
     final rawResponse = {
       '4um33znbt8l6x0vzvo0mperwj': null,

--- a/packages/apptive_grid_core/test/apptive_grid_uri_test.dart
+++ b/packages/apptive_grid_core/test/apptive_grid_uri_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:apptive_grid_core/apptive_grid_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -5,7 +7,6 @@ void main() {
   test('uriString returns uri as String', () {
     final uri = FormUri.fromUri('/api/a/1234');
 
-    // ignore: deprecated_member_use_from_same_package
     expect(uri.uriString, equals(uri.uri.toString()));
   });
 }

--- a/packages/apptive_grid_core/test/cross_reference_test.dart
+++ b/packages/apptive_grid_core/test/cross_reference_test.dart
@@ -158,7 +158,7 @@ void main() {
           as CrossReferenceDataEntity;
 
       expect(
-        dataEntity.gridUri.uri.toString(),
+        dataEntity.gridUri.toString(),
         (rawResponse['fields'] as List).first['schema']['gridUri'],
       );
     });
@@ -198,9 +198,9 @@ void main() {
     group('Schema Object', () {
       test('Value and EntityUri are set', () {
         final entity = CrossReferenceDataEntity(
-          gridUri: GridUri.fromUri('uri'),
+          gridUri: Uri.parse('uri'),
           value: 'Display Value',
-          entityUri: EntityUri.fromUri('entityUri'),
+          entityUri: Uri.parse('entityUri'),
         );
 
         expect(
@@ -214,9 +214,9 @@ void main() {
 
       test('No Value still produces object if EntityUri is set', () {
         final entity = CrossReferenceDataEntity(
-          gridUri: GridUri.fromUri('uri'),
+          gridUri: Uri.parse('uri'),
           value: null,
-          entityUri: EntityUri.fromUri('entityUri'),
+          entityUri: Uri.parse('entityUri'),
         );
 
         expect(
@@ -230,7 +230,7 @@ void main() {
 
       test('No Entity Uri sends null', () {
         final entity = CrossReferenceDataEntity(
-          gridUri: GridUri.fromUri('uri'),
+          gridUri: Uri.parse('uri'),
           value: 'Display Value',
           entityUri: null,
         );

--- a/packages/apptive_grid_core/test/direct_form_uri_test.dart
+++ b/packages/apptive_grid_core/test/direct_form_uri_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:apptive_grid_core/apptive_grid_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/apptive_grid_core/test/entity_uri_test.dart
+++ b/packages/apptive_grid_core/test/entity_uri_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:apptive_grid_core/apptive_grid_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/apptive_grid_core/test/form_data_test.dart
+++ b/packages/apptive_grid_core/test/form_data_test.dart
@@ -398,7 +398,7 @@ void main() {
       );
       expect(
         (formData.components![0].data as CrossReferenceDataEntity).gridUri,
-        GridUri.fromUri(
+        Uri.parse(
           '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06',
         ),
       );
@@ -476,13 +476,13 @@ void main() {
       expect(formData.components![0].data.value, equals('Yeah!'));
       expect(
         (formData.components![0].data as CrossReferenceDataEntity).entityUri,
-        EntityUri.fromUri(
+        Uri.parse(
           '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/entities/60d036ff0edfa83071816e0d',
         ),
       );
       expect(
         (formData.components![0].data as CrossReferenceDataEntity).gridUri,
-        GridUri.fromUri(
+        Uri.parse(
           '/api/users/609bc536dad545d1af7e82db/spaces/60d036dc0edfa83071816e00/grids/60d036f00edfa83071816e07/views/60d036f00edfa83071816e06',
         ),
       );

--- a/packages/apptive_grid_core/test/form_uri_test.dart
+++ b/packages/apptive_grid_core/test/form_uri_test.dart
@@ -67,14 +67,14 @@ void main() {
     group('Equality', () {
       test('From UriString equals to direct invocation', () {
         final parsed = RedirectFormUri.fromUri('/api/r/a1s2d3f4');
-        final direct = Uri.parse('/api/a/a1s2d3f4');
+        final direct = RedirectFormUri(components: ['a1s2d3f4']);
         expect(parsed, equals(direct));
         expect(parsed.hashCode, equals(direct.hashCode));
       });
 
       test('Different Values do not equal', () {
         final one = RedirectFormUri.fromUri('/api/r/a1s2d3f4');
-        final two = Uri.parse('/api/a/a1s2d3f45');
+        final two = RedirectFormUri(components: ['a1s2d3f45']);
         expect(one, isNot(two));
         expect(one.hashCode, isNot(two.hashCode));
       });

--- a/packages/apptive_grid_core/test/form_uri_test.dart
+++ b/packages/apptive_grid_core/test/form_uri_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:apptive_grid_core/apptive_grid_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -65,14 +67,14 @@ void main() {
     group('Equality', () {
       test('From UriString equals to direct invocation', () {
         final parsed = RedirectFormUri.fromUri('/api/r/a1s2d3f4');
-        final direct = RedirectFormUri(components: ['a1s2d3f4']);
+        final direct = Uri.parse('/api/a/a1s2d3f4');
         expect(parsed, equals(direct));
         expect(parsed.hashCode, equals(direct.hashCode));
       });
 
       test('Different Values do not equal', () {
         final one = RedirectFormUri.fromUri('/api/r/a1s2d3f4');
-        final two = RedirectFormUri(components: ['a1s2d3f45']);
+        final two = Uri.parse('/api/a/a1s2d3f45');
         expect(one, isNot(two));
         expect(one.hashCode, isNot(two.hashCode));
       });

--- a/packages/apptive_grid_core/test/grid_uri_test.dart
+++ b/packages/apptive_grid_core/test/grid_uri_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:apptive_grid_core/apptive_grid_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/apptive_grid_core/test/grid_view_uri_test.dart
+++ b/packages/apptive_grid_core/test/grid_view_uri_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:apptive_grid_core/apptive_grid_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/apptive_grid_core/test/multi_cross_reference_test.dart
+++ b/packages/apptive_grid_core/test/multi_cross_reference_test.dart
@@ -167,7 +167,7 @@ void main() {
           as MultiCrossReferenceDataEntity;
 
       expect(
-        dataEntity.gridUri.uri.toString(),
+        dataEntity.gridUri.toString(),
         (rawResponse['fields'] as List).first['schema']['items']['gridUri'],
       );
     });

--- a/packages/apptive_grid_core/test/redirect_form_uri_test.dart
+++ b/packages/apptive_grid_core/test/redirect_form_uri_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:apptive_grid_core/apptive_grid_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/apptive_grid_core/test/space_uri_test.dart
+++ b/packages/apptive_grid_core/test/space_uri_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:apptive_grid_core/apptive_grid_model.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/apptive_grid_form/CHANGELOG.md
+++ b/packages/apptive_grid_form/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.0-alpha.6
+* Deprecate all `ApptiveLink` in favor of plain `Uri`
+
 ## 0.10.0-alpha.5
 * Add `description` to forms
 * Upgraded to `flutter_lints 2`

--- a/packages/apptive_grid_form/README.md
+++ b/packages/apptive_grid_form/README.md
@@ -132,7 +132,7 @@ In order to display an ApptiveGrid Form in your App use the `ApptiveGridForm` Wi
         title: Text(widget.title),
       ),
       body: ApptiveGridForm(
-        formUri: FormUri.fromUri('YOUR_FORM_URI'),
+        uri: Uri.parse('YOUR_FORM_URI'),
       ),
     );
   }

--- a/packages/apptive_grid_form/example/lib/main.dart
+++ b/packages/apptive_grid_form/example/lib/main.dart
@@ -41,7 +41,7 @@ class MyApp extends StatelessWidget {
           title: const Text('ApptiveGrid Forms'),
         ),
         body: ApptiveGridForm(
-          formUri: FormUri.fromUri(
+          uri: Uri.parse(
             'YOUR_FORM_URI',
           ),
           titleStyle: Theme.of(context).textTheme.headline6,

--- a/packages/apptive_grid_form/lib/apptive_grid_form.dart
+++ b/packages/apptive_grid_form/lib/apptive_grid_form.dart
@@ -62,7 +62,8 @@ class ApptiveGridForm extends StatefulWidget {
   /// [FormUri..fromRedirect] with the id
   /// If you display Data gathered from a Grid you more likely want to use [FormUri..directForm]
   @Deprecated('Use `uri` instead')
-  FormUri get formUri => _formUri ?? FormUri.fromUri(_uri!.toString());
+  FormUri get formUri =>
+      _uri != null ? FormUri.fromUri(_uri!.toString()) : _formUri!;
 
   /// Style for the Form Title. If no style is provided [headline5] of the [TextTheme] will be used
   final TextStyle? titleStyle;

--- a/packages/apptive_grid_form/lib/apptive_grid_form.dart
+++ b/packages/apptive_grid_form/lib/apptive_grid_form.dart
@@ -23,7 +23,9 @@ class ApptiveGridForm extends StatefulWidget {
   /// The [formId] determines what Form is displayed. It works with empty and pre-filled forms.
   const ApptiveGridForm({
     Key? key,
-    required this.formUri,
+    Uri? uri,
+    // ignore: deprecated_member_use
+    @Deprecated('Use `uri` instead') FormUri? formUri,
     this.titleStyle,
     this.descriptionStyle,
     this.contentPadding,
@@ -37,14 +39,30 @@ class ApptiveGridForm extends StatefulWidget {
     this.scrollController,
     this.buttonAlignment = Alignment.center,
     this.buttonLabel,
-  }) : super(key: key);
+  })  : assert(uri != null || formUri != null),
+        _uri = uri,
+        _formUri = formUri,
+        super(key: key);
+
+  /// [Uri] of the Form to display
+  ///
+  /// If you copied the id from a EditLink or Preview Window on apptivegrid you should use:
+  /// [FormUri..fromRedirect] with the id
+  /// If you display Data gathered from a Grid you more likely want to use [FormUri..directForm]
+  Uri get uri => _uri ?? _formUri!.uri;
+
+  // TODO: Remove this once FormUri is removed
+  final Uri? _uri;
+  // ignore: deprecated_member_use
+  final FormUri? _formUri;
 
   /// [FormUri] of the Form to display
   ///
   /// If you copied the id from a EditLink or Preview Window on apptivegrid you should use:
   /// [FormUri..fromRedirect] with the id
   /// If you display Data gathered from a Grid you more likely want to use [FormUri..directForm]
-  final FormUri formUri;
+  @Deprecated('Use `uri` instead')
+  FormUri get formUri => _formUri ?? FormUri.fromUri(_uri!.toString());
 
   /// Style for the Form Title. If no style is provided [headline5] of the [TextTheme] will be used
   final TextStyle? titleStyle;
@@ -123,7 +141,7 @@ class ApptiveGridFormState extends State<ApptiveGridForm> {
   @override
   void didUpdateWidget(covariant ApptiveGridForm oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.formUri != oldWidget.formUri) {
+    if (widget.uri != oldWidget.uri) {
       loadForm();
     }
   }
@@ -167,7 +185,7 @@ class ApptiveGridFormState extends State<ApptiveGridForm> {
         _formData = null;
       });
     }
-    _client.loadForm(formUri: widget.formUri).then((value) {
+    _client.loadForm(uri: widget.uri).then((value) {
       if (widget.onFormLoaded != null) {
         widget.onFormLoaded!(value);
       }

--- a/packages/apptive_grid_form/lib/widgets/form_widget/cross_reference/cross_reference_dropdown_button_form_field.dart
+++ b/packages/apptive_grid_form/lib/widgets/form_widget/cross_reference/cross_reference_dropdown_button_form_field.dart
@@ -23,7 +23,7 @@ class _CrossReferenceDropdownButtonFormField<T extends DataEntity>
     _CrossReferenceDropdownButtonFormFieldState<T> state,
   ) onSelected;
 
-  final bool Function(EntityUri)? isSelected;
+  final bool Function(Uri)? isSelected;
 
   @override
   _CrossReferenceDropdownButtonFormFieldState<T> createState() =>
@@ -46,7 +46,7 @@ class _CrossReferenceDropdownButtonFormFieldState<T extends DataEntity>
 
   final _filterController = FilterController();
 
-  late final GridUri _gridUri;
+  late final Uri _gridUri;
 
   final _overlayKey = GlobalKey();
 
@@ -87,7 +87,7 @@ class _CrossReferenceDropdownButtonFormFieldState<T extends DataEntity>
     });
 
     ApptiveGrid.getClient(context, listen: false)
-        .loadGrid(gridUri: _gridUri)
+        .loadGrid(uri: _gridUri)
         .then((value) {
       for (final row in (value.rows ?? [])) {
         _controllers[row.id]?.dispose();
@@ -199,13 +199,9 @@ class _CrossReferenceDropdownButtonFormFieldState<T extends DataEntity>
           itemCount: _grid!.rows?.length ?? 0,
           itemBuilder: (context, index) {
             final row = _grid!.rows![index];
-            String path = _gridUri.uri.path;
-            final viewsIndex = path.indexOf('/views');
-            if (viewsIndex > 0) {
-              path = path.substring(0, viewsIndex);
-            }
-            final entityUri = EntityUri.fromUri(
-              '$path/entities/${row.id}',
+            String path = _grid!.links[ApptiveLinkType.entities]!.uri.path;
+            final entityUri = Uri.parse(
+              '$path/${row.id}',
             );
             return _RowMenuItem(
               key: ValueKey(widget.component.fieldId + row.id),

--- a/packages/apptive_grid_form/pubspec.yaml
+++ b/packages/apptive_grid_form/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_form
 description: A Flutter Package to display ApptiveGrid Forms inside a Flutter App.
-version: 0.10.0-alpha.5
+version: 0.10.0-alpha.6
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_form
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  apptive_grid_core: ^0.10.0-alpha.5
+  apptive_grid_core: ^0.10.0-alpha.6
   file_picker: ^4.3.0
   flutter:
     sdk: flutter

--- a/packages/apptive_grid_form/test/apptive_grid_form_test.dart
+++ b/packages/apptive_grid_form/test/apptive_grid_form_test.dart
@@ -15,7 +15,7 @@ void main() {
   late ApptiveGridClient client;
 
   setUpAll(() {
-    registerFallbackValue(RedirectFormUri(components: ['components']));
+    registerFallbackValue(Uri.parse('/api/a/components'));
     registerFallbackValue(http.Request('POST', Uri()));
     registerFallbackValue(
       ActionItem(
@@ -41,14 +41,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer(
         (realInvocation) async => FormData(
           id: 'formId',
@@ -70,15 +68,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
           hideTitle: true,
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer(
         (realInvocation) async => FormData(
           id: 'formId',
@@ -102,14 +98,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer(
         (realInvocation) async => FormData(
           id: 'formId',
@@ -131,15 +125,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
           hideDescription: true,
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer(
         (realInvocation) async => FormData(
           id: 'formId',
@@ -171,16 +163,14 @@ void main() {
     final target = TestApp(
       client: client,
       child: ApptiveGridForm(
-        formUri: RedirectFormUri(
-          components: ['form'],
-        ),
+        uri: Uri.parse('/api/a/forms/form'),
         onFormLoaded: (data) {
           completer.complete(data);
         },
       ),
     );
 
-    when(() => client.loadForm(formUri: RedirectFormUri(components: ['form'])))
+    when(() => client.loadForm(uri: Uri.parse('/api/a/form')))
         .thenAnswer((realInvocation) async => form);
 
     await tester.pumpWidget(target);
@@ -195,9 +185,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
       final form = FormData(
@@ -209,7 +197,7 @@ void main() {
         links: {},
       );
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => form);
 
       await tester.pumpWidget(target);
@@ -228,9 +216,7 @@ void main() {
         client: client,
         child: ApptiveGridForm(
           key: key,
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
       final form = FormData(
@@ -242,7 +228,7 @@ void main() {
         links: {},
       );
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer(
         (realInvocation) =>
             Future.delayed(const Duration(seconds: 2), () => form),
@@ -275,9 +261,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
       final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -291,7 +275,7 @@ void main() {
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => formData);
       when(() => client.submitForm(action, formData))
           .thenAnswer((_) async => http.Response('', 200));
@@ -310,9 +294,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
       final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -326,7 +308,7 @@ void main() {
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => formData);
       when(() => client.submitForm(action, formData))
           .thenAnswer((_) async => http.Response('', 200));
@@ -341,7 +323,7 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).called(2);
     });
   });
@@ -352,14 +334,12 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            formUri: RedirectFormUri(
-              components: ['form'],
-            ),
+            uri: Uri.parse('/api/a/forms/form'),
           ),
         );
 
         when(
-          () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+          () => client.loadForm(uri: Uri.parse('/api/a/form')),
         ).thenAnswer((_) => Future.error(''));
 
         await tester.pumpWidget(target);
@@ -374,13 +354,11 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            formUri: RedirectFormUri(
-              components: ['form'],
-            ),
+            uri: Uri.parse('/api/a/forms/form'),
           ),
         );
         when(
-          () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+          () => client.loadForm(uri: Uri.parse('/api/a/form')),
         ).thenAnswer((_) => Future.error(''));
 
         await tester.pumpWidget(target);
@@ -391,7 +369,7 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(
-          () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+          () => client.loadForm(uri: Uri.parse('/api/a/form')),
         ).called(2);
       });
     });
@@ -401,9 +379,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            formUri: RedirectFormUri(
-              components: ['form'],
-            ),
+            uri: Uri.parse('/api/a/forms/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -417,7 +393,7 @@ void main() {
         );
 
         when(
-          () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+          () => client.loadForm(uri: Uri.parse('/api/a/form')),
         ).thenAnswer((realInvocation) async => formData);
         when(() => client.submitForm(action, formData))
             .thenAnswer((_) => Future.error(''));
@@ -436,9 +412,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            formUri: RedirectFormUri(
-              components: ['form'],
-            ),
+            uri: Uri.parse('/api/a/forms/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -452,7 +426,7 @@ void main() {
         );
 
         when(
-          () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+          () => client.loadForm(uri: Uri.parse('/api/a/form')),
         ).thenAnswer((realInvocation) async => formData);
         when(() => client.submitForm(action, formData))
             .thenAnswer((_) => Future.error(''));
@@ -468,13 +442,11 @@ void main() {
       });
 
       testWidgets('Back to Form shows Form', (tester) async {
-        final formUri = RedirectFormUri(
-          components: ['form'],
-        );
+        final formUri = Uri.parse('/api/a/forms/form');
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            formUri: formUri,
+            uri: formUri,
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -488,7 +460,7 @@ void main() {
         );
 
         when(
-          () => client.loadForm(formUri: formUri),
+          () => client.loadForm(uri: formUri),
         ).thenAnswer((realInvocation) async => formData);
         when(() => client.submitForm(action, formData))
             .thenAnswer((_) => Future.error(''));
@@ -504,7 +476,7 @@ void main() {
 
         expect(find.text('Form Title'), findsOneWidget);
         // Don't reload here
-        verify(() => client.loadForm(formUri: formUri)).called(1);
+        verify(() => client.loadForm(uri: formUri)).called(1);
       });
 
       testWidgets('Cache Response. Additional Answer shows Form',
@@ -524,9 +496,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            formUri: RedirectFormUri(
-              components: ['form'],
-            ),
+            uri: Uri.parse('/api/a/forms/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -540,7 +510,7 @@ void main() {
         );
 
         when(
-          () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+          () => client.loadForm(uri: Uri.parse('/api/a/form')),
         ).thenAnswer((realInvocation) async => formData);
         when(() => client.submitForm(action, formData))
             .thenAnswer((_) async => http.Response('', 500));
@@ -555,7 +525,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Form Title'), findsOneWidget);
-        verify(() => client.loadForm(formUri: any(named: 'formUri'))).called(2);
+        verify(() => client.loadForm(uri: any(named: 'uri'))).called(2);
       });
     });
 
@@ -564,9 +534,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            formUri: RedirectFormUri(
-              components: ['form'],
-            ),
+            uri: Uri.parse('/api/a/forms/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -580,7 +548,7 @@ void main() {
         );
 
         when(
-          () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+          () => client.loadForm(uri: Uri.parse('/api/a/form')),
         ).thenAnswer((realInvocation) async => formData);
         when(() => client.submitForm(action, formData))
             .thenAnswer((_) => Future.error(Exception('Testing Errors')));
@@ -599,9 +567,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            formUri: RedirectFormUri(
-              components: ['form'],
-            ),
+            uri: Uri.parse('/api/a/forms/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -615,7 +581,7 @@ void main() {
         );
 
         when(
-          () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+          () => client.loadForm(uri: Uri.parse('/api/a/form')),
         ).thenAnswer((realInvocation) async => formData);
         when(() => client.submitForm(action, formData)).thenAnswer(
           (_) => Future.error(http.Response('Testing Errors', 400)),
@@ -638,9 +604,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
           onActionSuccess: (action, data) async {
             return false;
           },
@@ -657,7 +621,7 @@ void main() {
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => formData);
       when(() => client.submitForm(action, formData))
           .thenAnswer((_) async => http.Response('', 200));
@@ -674,9 +638,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
           onError: (error) async {
             return false;
           },
@@ -693,7 +655,7 @@ void main() {
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => formData);
       when(() => client.submitForm(action, formData))
           .thenAnswer((_) => Future.error(''));
@@ -720,7 +682,7 @@ void main() {
       schema: {},
     );
 
-    final formUri = RedirectFormUri(components: ['form']);
+    final formUri = Uri.parse('/api/a/form');
     const env = ApptiveGridEnvironment.production;
 
     setUpAll(() {
@@ -735,7 +697,7 @@ void main() {
 
       when(
         () => httpClient.get(
-          Uri.parse(env.url + formUri.uri.toString()),
+          Uri.parse(env.url + formUri.toString()),
           headers: any(named: 'headers'),
         ),
       ).thenAnswer(
@@ -752,7 +714,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: formUri,
+          uri: formUri,
         ),
       );
 
@@ -789,7 +751,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: formUri,
+          uri: formUri,
         ),
       );
 
@@ -826,14 +788,12 @@ void main() {
         client: client,
         child: ApptiveGridForm(
           key: key,
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => form);
 
       await tester.pumpWidget(target);
@@ -863,14 +823,12 @@ void main() {
         client: client,
         child: ApptiveGridForm(
           key: key,
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => formData);
       when(() => client.submitForm(action, formData))
           .thenAnswer((_) async => http.Response('', 200));
@@ -907,14 +865,12 @@ void main() {
         ),
         child: ApptiveGridForm(
           key: key,
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => formData);
       when(() => client.submitForm(action, formData))
           .thenAnswer((_) async => http.Response('', 400));
@@ -937,9 +893,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
       final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -954,7 +908,7 @@ void main() {
 
       final actionCompleter = Completer<http.Response>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => formData);
       when(() => client.submitForm(action, formData))
           .thenAnswer((_) => actionCompleter.future);
@@ -979,9 +933,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
           buttonLabel: label,
         ),
       );
@@ -997,7 +949,7 @@ void main() {
 
       final actionCompleter = Completer<http.Response>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => formData);
       when(() => client.submitForm(action, formData))
           .thenAnswer((_) => actionCompleter.future);
@@ -1048,13 +1000,11 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['form'],
-          ),
+          uri: Uri.parse('/api/a/form'),
         ),
       );
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['form'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/form')),
       ).thenAnswer((realInvocation) async => formData);
 
       await tester.pumpWidget(target);
@@ -1072,14 +1022,14 @@ void main() {
 
   group('Reload', () {
     testWidgets('Changing Form Uri triggers reload', (tester) async {
-      final firstForm = FormUri.fromUri('/form1');
-      final secondForm = FormUri.fromUri('/form2');
+      final firstForm = Uri.parse('/form1');
+      final secondForm = Uri.parse('/form2');
 
       final globalKey = GlobalKey<_ChangingFormWidgetState>();
       final client = MockApptiveGridClient();
 
       when(client.sendPendingActions).thenAnswer((_) async {});
-      when(() => client.loadForm(formUri: any(named: 'formUri'))).thenAnswer(
+      when(() => client.loadForm(uri: any(named: 'uri'))).thenAnswer(
         (_) async => FormData(
           id: 'formId',
           title: 'title',
@@ -1104,8 +1054,8 @@ void main() {
       globalKey.currentState?._changeForm();
       await tester.pump();
 
-      verify(() => client.loadForm(formUri: firstForm)).called(1);
-      verify(() => client.loadForm(formUri: secondForm)).called(1);
+      verify(() => client.loadForm(uri: firstForm)).called(1);
+      verify(() => client.loadForm(uri: secondForm)).called(1);
     });
   });
 }
@@ -1117,15 +1067,15 @@ class _ChangingFormWidget extends StatefulWidget {
     required this.form2,
   }) : super(key: key);
 
-  final FormUri form1;
-  final FormUri form2;
+  final Uri form1;
+  final Uri form2;
 
   @override
   State<_ChangingFormWidget> createState() => _ChangingFormWidgetState();
 }
 
 class _ChangingFormWidgetState extends State<_ChangingFormWidget> {
-  late FormUri _displayingUri;
+  late Uri _displayingUri;
 
   @override
   void initState() {
@@ -1142,6 +1092,6 @@ class _ChangingFormWidgetState extends State<_ChangingFormWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return ApptiveGridForm(formUri: _displayingUri);
+    return ApptiveGridForm(uri: _displayingUri);
   }
 }

--- a/packages/apptive_grid_form/test/apptive_grid_form_test.dart
+++ b/packages/apptive_grid_form/test/apptive_grid_form_test.dart
@@ -163,7 +163,7 @@ void main() {
     final target = TestApp(
       client: client,
       child: ApptiveGridForm(
-        uri: Uri.parse('/api/a/forms/form'),
+        uri: Uri.parse('/api/a/form'),
         onFormLoaded: (data) {
           completer.complete(data);
         },
@@ -334,7 +334,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            uri: Uri.parse('/api/a/forms/form'),
+            uri: Uri.parse('/api/a/form'),
           ),
         );
 
@@ -354,7 +354,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            uri: Uri.parse('/api/a/forms/form'),
+            uri: Uri.parse('/api/a/form'),
           ),
         );
         when(
@@ -379,7 +379,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            uri: Uri.parse('/api/a/forms/form'),
+            uri: Uri.parse('/api/a/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -412,7 +412,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            uri: Uri.parse('/api/a/forms/form'),
+            uri: Uri.parse('/api/a/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -442,7 +442,7 @@ void main() {
       });
 
       testWidgets('Back to Form shows Form', (tester) async {
-        final formUri = Uri.parse('/api/a/forms/form');
+        final formUri = Uri.parse('/api/a/form');
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
@@ -496,7 +496,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            uri: Uri.parse('/api/a/forms/form'),
+            uri: Uri.parse('/api/a/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -534,7 +534,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            uri: Uri.parse('/api/a/forms/form'),
+            uri: Uri.parse('/api/a/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');
@@ -567,7 +567,7 @@ void main() {
         final target = TestApp(
           client: client,
           child: ApptiveGridForm(
-            uri: Uri.parse('/api/a/forms/form'),
+            uri: Uri.parse('/api/a/form'),
           ),
         );
         final action = ApptiveLink(uri: Uri.parse('uri'), method: 'method');

--- a/packages/apptive_grid_form/test/apptive_grid_form_test.dart
+++ b/packages/apptive_grid_form/test/apptive_grid_form_test.dart
@@ -1058,6 +1058,45 @@ void main() {
       verify(() => client.loadForm(uri: secondForm)).called(1);
     });
   });
+
+  group('FormUri', () {
+    final uri = Uri.parse('uri');
+    // ignore: deprecated_member_use
+    final formUri = FormUri.fromUri('formUri');
+
+    test('No FormUri returns Uri as FormUri', () async {
+      final apptiveGridForm = ApptiveGridForm(
+        uri: uri,
+      );
+
+      // ignore: deprecated_member_use_from_same_package
+      expect(apptiveGridForm.formUri.uri, equals(uri));
+      expect(apptiveGridForm.uri, equals(uri));
+    });
+
+    test('No Uri returns FormUri', () async {
+      final apptiveGridForm = ApptiveGridForm(
+        // ignore: deprecated_member_use_from_same_package
+        formUri: formUri,
+      );
+
+      // ignore: deprecated_member_use_from_same_package
+      expect(apptiveGridForm.formUri.uri, equals(formUri.uri));
+      expect(apptiveGridForm.uri, equals(formUri.uri));
+    });
+
+    test('Uri prioritized over formUri', () async {
+      final apptiveGridForm = ApptiveGridForm(
+        uri: uri,
+        // ignore: deprecated_member_use_from_same_package
+        formUri: formUri,
+      );
+
+      // ignore: deprecated_member_use_from_same_package
+      expect(apptiveGridForm.formUri.uri, equals(uri));
+      expect(apptiveGridForm.uri, equals(uri));
+    });
+  });
 }
 
 class _ChangingFormWidget extends StatefulWidget {

--- a/packages/apptive_grid_form/test/component_mapper_test.dart
+++ b/packages/apptive_grid_form/test/component_mapper_test.dart
@@ -120,7 +120,7 @@ void main() {
       final component = CrossReferenceFormComponent(
         fieldId: 'id',
         data: CrossReferenceDataEntity(
-          gridUri: GridUri(user: 'user', space: 'space', grid: 'grid'),
+          gridUri: Uri.parse('/api/a/user/spaces/space/grids/grid'),
         ),
         property: 'Property',
         required: false,
@@ -136,7 +136,7 @@ void main() {
       final component = MultiCrossReferenceFormComponent(
         fieldId: 'id',
         data: MultiCrossReferenceDataEntity(
-          gridUri: GridUri(user: 'user', space: 'space', grid: 'grid'),
+          gridUri: Uri.parse('/api/a/user/spaces/space/grids/grid'),
         ),
         property: 'Property',
         required: false,

--- a/packages/apptive_grid_form/test/component_test.dart
+++ b/packages/apptive_grid_form/test/component_test.dart
@@ -72,15 +72,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       final completer = Completer<FormData>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
       when(() => client.submitForm(action, any()))
           .thenAnswer((realInvocation) async {
@@ -122,14 +120,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
 
       await tester.pumpWidget(target);
@@ -166,15 +162,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       final completer = Completer<FormData>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
       when(() => client.submitForm(action, any()))
           .thenAnswer((realInvocation) async {
@@ -228,15 +222,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       final completer = Completer<FormData>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
       when(() => client.submitForm(action, any()))
           .thenAnswer((realInvocation) async {
@@ -300,14 +292,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
 
       await tester.pumpWidget(target);
@@ -344,15 +334,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       final completer = Completer<FormData>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
       when(() => client.submitForm(action, any()))
           .thenAnswer((realInvocation) async {
@@ -405,14 +393,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
 
       await tester.pumpWidget(target);
@@ -449,15 +435,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       final completer = Completer<FormData>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
       when(() => client.submitForm(action, any()))
           .thenAnswer((realInvocation) async {
@@ -498,14 +482,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
 
       await tester.pumpWidget(target);
@@ -534,14 +516,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
 
       await tester.pumpWidget(target);
@@ -578,15 +558,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       final completer = Completer<FormData>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
       when(() => client.submitForm(action, any()))
           .thenAnswer((realInvocation) async {
@@ -627,14 +605,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
 
       await tester.pumpWidget(target);
@@ -663,14 +639,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
 
       await tester.pumpWidget(target);
@@ -707,15 +681,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       final completer = Completer<FormData>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
       when(() => client.submitForm(action, any()))
           .thenAnswer((realInvocation) async {
@@ -757,14 +729,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
 
       await tester.pumpWidget(target);
@@ -801,15 +771,13 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       final completer = Completer<FormData>();
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
       when(() => client.submitForm(action, any()))
           .thenAnswer((realInvocation) async {
@@ -860,14 +828,12 @@ void main() {
       final target = TestApp(
         client: client,
         child: ApptiveGridForm(
-          formUri: RedirectFormUri(
-            components: ['formId'],
-          ),
+          uri: Uri.parse('/api/a/formId'),
         ),
       );
 
       when(
-        () => client.loadForm(formUri: RedirectFormUri(components: ['formId'])),
+        () => client.loadForm(uri: Uri.parse('/api/a/formId')),
       ).thenAnswer((_) async => formData);
 
       await tester.pumpWidget(target);

--- a/packages/apptive_grid_form/test/cross_reference_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/cross_reference_form_widget_test.dart
@@ -21,7 +21,8 @@ void main() {
       ),
     );
     registerFallbackValue(
-        Uri.parse('/api/a/users/user/spaces/space/grids/grid'));
+      Uri.parse('/api/users/user/spaces/space/grids/grid'),
+    );
   });
 
   group('FormWidget', () {
@@ -29,7 +30,7 @@ void main() {
     late Widget target;
     late GlobalKey<FormState> formKey;
 
-    final gridUri = Uri.parse('/api/a/users/user/spaces/space/grids/grid');
+    final gridUri = Uri.parse('/api/users/user/spaces/space/grids/grid');
     final field = GridField(id: 'field', name: 'Name', type: DataType.text);
     final grid = Grid(
       id: 'grid',
@@ -212,7 +213,8 @@ void main() {
               value: 'CrossRef',
               gridUri: Uri.parse('/api/a/user/spaces/space/grids/grid'),
               entityUri: Uri.parse(
-                  '/api/a/user/spaces/space/grids/grid/entities/entity'),
+                '/api/a/user/spaces/space/grids/grid/entities/entity',
+              ),
             ),
             fieldId: 'fieldId',
             required: true,

--- a/packages/apptive_grid_form/test/cross_reference_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/cross_reference_form_widget_test.dart
@@ -20,7 +20,8 @@ void main() {
         links: {},
       ),
     );
-    registerFallbackValue(GridUri(user: 'user', space: 'space', grid: 'grid'));
+    registerFallbackValue(
+        Uri.parse('/api/a/users/user/spaces/space/grids/grid'));
   });
 
   group('FormWidget', () {
@@ -28,7 +29,7 @@ void main() {
     late Widget target;
     late GlobalKey<FormState> formKey;
 
-    final gridUri = GridUri(user: 'user', space: 'space', grid: 'grid');
+    final gridUri = Uri.parse('/api/a/users/user/spaces/space/grids/grid');
     final field = GridField(id: 'field', name: 'Name', type: DataType.text);
     final grid = Grid(
       id: 'grid',
@@ -47,9 +48,9 @@ void main() {
         ),
       ],
       links: {
-        ApptiveLinkType.self: ApptiveLink(uri: gridUri.uri, method: 'get'),
+        ApptiveLinkType.self: ApptiveLink(uri: gridUri, method: 'get'),
         ApptiveLinkType.entities: ApptiveLink(
-          uri: gridUri.uri.replace(path: '${gridUri.uri.path}/entities'),
+          uri: gridUri.replace(path: '${gridUri.path}/entities'),
           method: 'get',
         ),
       },
@@ -67,7 +68,7 @@ void main() {
       );
 
       when(() => client.sendPendingActions()).thenAnswer((_) async {});
-      when(() => client.loadGrid(gridUri: any(named: 'gridUri')))
+      when(() => client.loadGrid(uri: any(named: 'uri')))
           .thenAnswer((_) async => grid);
 
       target = TestApp(
@@ -112,43 +113,8 @@ void main() {
       expect(find.text('First'), findsOneWidget);
     });
 
-    testWidgets('Strips /views from url', (tester) async {
-      final gridUri =
-          GridUri(user: 'user', space: 'space', grid: 'grid', view: 'view');
-      final testComponent = CrossReferenceFormComponent(
-        property: 'Property',
-        data: CrossReferenceDataEntity(
-          gridUri: gridUri,
-        ),
-        fieldId: 'fieldId',
-        required: true,
-      );
-
-      target = TestApp(
-        client: client,
-        child: Form(
-          key: formKey,
-          child: CrossReferenceFormWidget(component: testComponent),
-        ),
-      );
-
-      await tester.pumpWidget(target);
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.byIcon(Icons.arrow_drop_down));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('First').last);
-      await tester.pumpAndSettle();
-
-      expect(
-        testComponent.data.entityUri?.uri.toString(),
-        equals('/api/users/user/spaces/space/grids/grid/entities/row1'),
-      );
-    });
-
     testWidgets('Loading Grid has Error, displays error', (tester) async {
-      when(() => client.loadGrid(gridUri: gridUri))
+      when(() => client.loadGrid(uri: gridUri))
           .thenAnswer((_) => Future.error('Error loading Grid'));
 
       await tester.pumpWidget(target);
@@ -165,7 +131,7 @@ void main() {
 
     testWidgets('Loading Grid shows Loading State', (tester) async {
       final completer = Completer<Grid>();
-      when(() => client.loadGrid(gridUri: gridUri))
+      when(() => client.loadGrid(uri: gridUri))
           .thenAnswer((_) => completer.future);
 
       await tester.pumpWidget(target);
@@ -208,15 +174,15 @@ void main() {
           ),
         ],
         links: {
-          ApptiveLinkType.self: ApptiveLink(uri: gridUri.uri, method: 'get'),
+          ApptiveLinkType.self: ApptiveLink(uri: gridUri, method: 'get'),
           ApptiveLinkType.entities: ApptiveLink(
-            uri: gridUri.uri.replace(path: '${gridUri.uri.path}/entities'),
+            uri: gridUri.replace(path: '${gridUri.path}/entities'),
             method: 'get',
           ),
         },
       );
 
-      when(() => client.loadGrid(gridUri: gridUri))
+      when(() => client.loadGrid(uri: gridUri))
           .thenAnswer((_) async => gridWithNull);
 
       await tester.pumpWidget(target);
@@ -244,13 +210,9 @@ void main() {
             property: 'Property',
             data: CrossReferenceDataEntity(
               value: 'CrossRef',
-              gridUri: GridUri(user: 'user', space: 'space', grid: 'grid'),
-              entityUri: EntityUri(
-                user: 'user',
-                space: 'space',
-                grid: 'grid',
-                entity: 'entity',
-              ),
+              gridUri: Uri.parse('/api/a/user/spaces/space/grids/grid'),
+              entityUri: Uri.parse(
+                  '/api/a/user/spaces/space/grids/grid/entities/entity'),
             ),
             fieldId: 'fieldId',
             required: true,
@@ -260,7 +222,7 @@ void main() {
         schema: null,
       );
       final client = MockApptiveGridClient();
-      when(() => client.loadGrid(gridUri: any(named: 'gridUri'))).thenAnswer(
+      when(() => client.loadGrid(uri: any(named: 'uri'))).thenAnswer(
         (invocation) async => Grid(
           id: 'grid',
           name: 'name',

--- a/packages/apptive_grid_form/test/multi_cross_reference_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/multi_cross_reference_form_widget_test.dart
@@ -21,7 +21,8 @@ void main() {
       ),
     );
     registerFallbackValue(
-        Uri.parse('/api/a/users/user/spaces/space/grids/grid'));
+      Uri.parse('/api/users/user/spaces/space/grids/grid'),
+    );
   });
 
   group('FormWidget', () {
@@ -29,7 +30,7 @@ void main() {
     late Widget target;
     late GlobalKey<FormState> formKey;
 
-    final gridUri = Uri.parse('/api/a/users/user/spaces/space/grids/grid');
+    final gridUri = Uri.parse('/api/users/user/spaces/space/grids/grid');
     final field = GridField(id: 'field', name: 'Name', type: DataType.text);
     final grid = Grid(
       id: 'grid',
@@ -264,7 +265,8 @@ void main() {
                   value: 'CrossRef',
                   gridUri: Uri.parse('/api/a/user/spaces/space/grids/grid'),
                   entityUri: Uri.parse(
-                      '/api/a/user/spaces/space/grids/grid/entities/entity'),
+                    '/api/a/user/spaces/space/grids/grid/entities/entity',
+                  ),
                 ),
               ],
             ),

--- a/packages/apptive_grid_form/test/multi_cross_reference_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/multi_cross_reference_form_widget_test.dart
@@ -20,7 +20,8 @@ void main() {
         schema: {},
       ),
     );
-    registerFallbackValue(GridUri(user: 'user', space: 'space', grid: 'grid'));
+    registerFallbackValue(
+        Uri.parse('/api/a/users/user/spaces/space/grids/grid'));
   });
 
   group('FormWidget', () {
@@ -28,7 +29,7 @@ void main() {
     late Widget target;
     late GlobalKey<FormState> formKey;
 
-    final gridUri = GridUri(user: 'user', space: 'space', grid: 'grid');
+    final gridUri = Uri.parse('/api/a/users/user/spaces/space/grids/grid');
     final field = GridField(id: 'field', name: 'Name', type: DataType.text);
     final grid = Grid(
       id: 'grid',
@@ -47,9 +48,9 @@ void main() {
         ),
       ],
       links: {
-        ApptiveLinkType.self: ApptiveLink(uri: gridUri.uri, method: 'get'),
+        ApptiveLinkType.self: ApptiveLink(uri: gridUri, method: 'get'),
         ApptiveLinkType.entities: ApptiveLink(
-          uri: gridUri.uri.replace(path: '${gridUri.uri.path}/entities'),
+          uri: gridUri.replace(path: '${gridUri.path}/entities'),
           method: 'get',
         ),
       },
@@ -67,8 +68,7 @@ void main() {
       );
 
       when(() => client.sendPendingActions()).thenAnswer((_) async {});
-      when(() => client.loadGrid(gridUri: gridUri))
-          .thenAnswer((_) async => grid);
+      when(() => client.loadGrid(uri: gridUri)).thenAnswer((_) async => grid);
 
       target = TestApp(
         client: client,
@@ -163,7 +163,7 @@ void main() {
     });
 
     testWidgets('Loading Grid has Error, displays error', (tester) async {
-      when(() => client.loadGrid(gridUri: gridUri))
+      when(() => client.loadGrid(uri: gridUri))
           .thenAnswer((_) => Future.error('Error loading Grid'));
 
       await tester.pumpWidget(target);
@@ -180,7 +180,7 @@ void main() {
 
     testWidgets('Loading Grid shows Loading State', (tester) async {
       final completer = Completer<Grid>();
-      when(() => client.loadGrid(gridUri: gridUri))
+      when(() => client.loadGrid(uri: gridUri))
           .thenAnswer((_) => completer.future);
 
       await tester.pumpWidget(target);
@@ -223,15 +223,15 @@ void main() {
           ),
         ],
         links: {
-          ApptiveLinkType.self: ApptiveLink(uri: gridUri.uri, method: 'get'),
+          ApptiveLinkType.self: ApptiveLink(uri: gridUri, method: 'get'),
           ApptiveLinkType.entities: ApptiveLink(
-            uri: gridUri.uri.replace(path: '${gridUri.uri.path}/entities'),
+            uri: gridUri.replace(path: '${gridUri.path}/entities'),
             method: 'get',
           ),
         },
       );
 
-      when(() => client.loadGrid(gridUri: gridUri))
+      when(() => client.loadGrid(uri: gridUri))
           .thenAnswer((_) async => gridWithNull);
 
       await tester.pumpWidget(target);
@@ -258,17 +258,13 @@ void main() {
           MultiCrossReferenceFormComponent(
             property: 'Property',
             data: MultiCrossReferenceDataEntity(
-              gridUri: GridUri(user: 'user', space: 'space', grid: 'grid'),
+              gridUri: Uri.parse('/api/a/user/spaces/space/grids/grid'),
               references: [
                 CrossReferenceDataEntity(
                   value: 'CrossRef',
-                  gridUri: GridUri(user: 'user', space: 'space', grid: 'grid'),
-                  entityUri: EntityUri(
-                    user: 'user',
-                    space: 'space',
-                    grid: 'grid',
-                    entity: 'entity',
-                  ),
+                  gridUri: Uri.parse('/api/a/user/spaces/space/grids/grid'),
+                  entityUri: Uri.parse(
+                      '/api/a/user/spaces/space/grids/grid/entities/entity'),
                 ),
               ],
             ),
@@ -280,7 +276,7 @@ void main() {
         schema: null,
       );
       final client = MockApptiveGridClient();
-      when(() => client.loadGrid(gridUri: any(named: 'gridUri'))).thenAnswer(
+      when(() => client.loadGrid(uri: any(named: 'uri'))).thenAnswer(
         (invocation) async => Grid(
           id: 'grid',
           name: 'name',

--- a/packages/apptive_grid_grid_builder/CHANGELOG.md
+++ b/packages/apptive_grid_grid_builder/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.0-alpha.5
+* Deprecate all `ApptiveLink` in favor of plain `Uri`
+
 ## 0.9.0-alpha.4
 * Upgraded to `flutter_lints 2`
 

--- a/packages/apptive_grid_grid_builder/README.md
+++ b/packages/apptive_grid_grid_builder/README.md
@@ -4,7 +4,7 @@
 
 A Flutter Package to build Widgets based on Grid Data
 
-## Setup
+## Usage
 
 In order to use any ApptiveGrid Feature you must wrap your App with a `ApptiveGrid` Widget
 
@@ -19,7 +19,14 @@ void main() {
           autoAuthenticate = true,
         ),
       ),
-      child: MyApp(),
+      child: MyApp(
+        child: ApptiveGridGridBuilder(
+          uri: Uri.parse('LINK_TO_GRID'),
+          builder: (context, snapshot) {
+            // Build your app based on snapshot.data
+          }
+        ),
+      ),
     ),
   );
 }

--- a/packages/apptive_grid_grid_builder/example/lib/contact_list.dart
+++ b/packages/apptive_grid_grid_builder/example/lib/contact_list.dart
@@ -60,11 +60,7 @@ class _MyHomePageState extends State<_MyHomePage> {
       // Add the ApptiveGridGridBuilder to your Widget Tree
       body: ApptiveGridGridBuilder(
         key: _builderKey,
-        gridUri: GridUri(
-          user: 'USER_ID',
-          space: 'SPACE_ID',
-          grid: 'GRID_ID',
-        ),
+        uri: Uri.parse('/api/a/users/USER_ID/spaces/SPACE_ID/grids/GRID_ID'),
         builder: (context, snapshot) {
           if (snapshot.hasError) {
             return Center(

--- a/packages/apptive_grid_grid_builder/example/lib/contact_list.dart
+++ b/packages/apptive_grid_grid_builder/example/lib/contact_list.dart
@@ -60,7 +60,7 @@ class _MyHomePageState extends State<_MyHomePage> {
       // Add the ApptiveGridGridBuilder to your Widget Tree
       body: ApptiveGridGridBuilder(
         key: _builderKey,
-        uri: Uri.parse('/api/a/users/USER_ID/spaces/SPACE_ID/grids/GRID_ID'),
+        uri: Uri.parse('/api/users/USER_ID/spaces/SPACE_ID/grids/GRID_ID'),
         builder: (context, snapshot) {
           if (snapshot.hasError) {
             return Center(

--- a/packages/apptive_grid_grid_builder/example/lib/main.dart
+++ b/packages/apptive_grid_grid_builder/example/lib/main.dart
@@ -84,7 +84,7 @@ class _MyHomePageState extends State<_MyHomePage> {
       // Add the ApptiveGridGridBuilder to your Widget Tree
       body: ApptiveGridGridBuilder(
         key: _builderKey,
-        uri: Uri.parse('/api/a/users/USER_ID/spaces/SPACE_ID/grids/GRID_ID'),
+        uri: Uri.parse('/api/users/USER_ID/spaces/SPACE_ID/grids/GRID_ID'),
         sorting: _sorting,
         builder: (context, snapshot) {
           if (snapshot.hasError) {

--- a/packages/apptive_grid_grid_builder/example/lib/main.dart
+++ b/packages/apptive_grid_grid_builder/example/lib/main.dart
@@ -84,11 +84,7 @@ class _MyHomePageState extends State<_MyHomePage> {
       // Add the ApptiveGridGridBuilder to your Widget Tree
       body: ApptiveGridGridBuilder(
         key: _builderKey,
-        gridUri: GridUri(
-          user: 'USER_ID',
-          space: 'SPACE_ID',
-          grid: 'GRID_ID',
-        ),
+        uri: Uri.parse('/api/a/users/USER_ID/spaces/SPACE_ID/grids/GRID_ID'),
         sorting: _sorting,
         builder: (context, snapshot) {
           if (snapshot.hasError) {

--- a/packages/apptive_grid_grid_builder/lib/apptive_grid_grid_builder.dart
+++ b/packages/apptive_grid_grid_builder/lib/apptive_grid_grid_builder.dart
@@ -11,15 +11,32 @@ class ApptiveGridGridBuilder extends StatefulWidget {
   /// Creates a Builder Widet
   const ApptiveGridGridBuilder({
     Key? key,
-    required this.gridUri,
+    Uri? uri,
+    @Deprecated('Use `uri` instead')
+        // ignore: deprecated_member_use
+        GridUri? gridUri,
     this.initialData,
     this.sorting,
     this.filter,
     required this.builder,
-  }) : super(key: key);
+  })  : assert(uri != null || gridUri != null),
+        _uri = uri,
+        _gridUri = gridUri,
+        super(key: key);
+
+  // TODO: Remove once GridUri is removed. Make _uri public and required
+  // ignore: deprecated_member_use
+  final GridUri? _gridUri;
+  final Uri? _uri;
+
+  /// Uri of the grid that should be used
+  // ignore: deprecated_member_use
+  Uri get uri => _uri ?? _gridUri!.uri;
 
   /// GridUri of the grid that should be used
-  final GridUri gridUri;
+  // ignore: deprecated_member_use
+  @Deprecated('Use `uri` instead')
+  GridUri get gridUri => _gridUri ?? GridUri.fromUri(_uri!.toString());
 
   /// Initial [Grid] data that should be shown
   final Grid? initialData;
@@ -59,7 +76,7 @@ class ApptiveGridGridBuilderState extends State<ApptiveGridGridBuilder> {
     super.didUpdateWidget(oldWidget);
     if (!listEquals(oldWidget.sorting, widget.sorting) ||
         oldWidget.filter != widget.filter ||
-        oldWidget.gridUri != widget.gridUri) {
+        oldWidget.uri != widget.uri) {
       reload(listen: false);
     }
   }
@@ -77,7 +94,7 @@ class ApptiveGridGridBuilderState extends State<ApptiveGridGridBuilder> {
   }) {
     return ApptiveGrid.getClient(context, listen: listen)
         .loadGrid(
-          gridUri: widget.gridUri,
+          uri: widget.uri,
           sorting: widget.sorting,
           filter: widget.filter,
         )

--- a/packages/apptive_grid_grid_builder/lib/apptive_grid_grid_builder.dart
+++ b/packages/apptive_grid_grid_builder/lib/apptive_grid_grid_builder.dart
@@ -36,7 +36,8 @@ class ApptiveGridGridBuilder extends StatefulWidget {
   /// GridUri of the grid that should be used
   // ignore: deprecated_member_use
   @Deprecated('Use `uri` instead')
-  GridUri get gridUri => _gridUri ?? GridUri.fromUri(_uri!.toString());
+  GridUri get gridUri =>
+      _uri != null ? GridUri.fromUri(_uri!.toString()) : _gridUri!;
 
   /// Initial [Grid] data that should be shown
   final Grid? initialData;

--- a/packages/apptive_grid_grid_builder/pubspec.yaml
+++ b/packages/apptive_grid_grid_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_grid_builder
 description: A Flutter Package to build Widgets based on Data from an ApptiveGrid Grid.
-version: 0.9.0-alpha.4
+version: 0.9.0-alpha.5
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_grid_builder
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  apptive_grid_core: ^0.10.0-alpha.4
+  apptive_grid_core: ^0.10.0-alpha.6
   flutter:
     sdk: flutter
 

--- a/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
+++ b/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
@@ -14,7 +14,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(
-      Uri.parse('/api/a/users/user/spaces/space/grids/grid'),
+      Uri.parse('/api/users/user/spaces/space/grids/grid'),
     );
     registerFallbackValue(
       [ApptiveGridSorting(fieldId: 'fieldId', order: SortOrder.asc)],
@@ -31,7 +31,7 @@ void main() {
     final target = TestApp(
       client: client,
       child: ApptiveGridGridBuilder(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
         builder: (context, snapshot) {
           if (snapshot.hasData) {
             return Text(snapshot.data!.name);
@@ -45,7 +45,7 @@ void main() {
     final title = 'Title';
     when(
       () => client.loadGrid(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
       ),
     ).thenAnswer(
       (_) async => Grid(
@@ -67,7 +67,7 @@ void main() {
     final target = TestApp(
       client: client,
       child: ApptiveGridGridBuilder(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
         initialData: Grid(
           id: gridId,
           name: 'Initial Title',
@@ -88,7 +88,7 @@ void main() {
     final title = 'Title';
     when(
       () => client.loadGrid(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
       ),
     ).thenAnswer(
       (_) async => Grid(
@@ -112,7 +112,7 @@ void main() {
     final target = TestApp(
       client: client,
       child: ApptiveGridGridBuilder(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
         builder: (context, snapshot) {
           if (snapshot.hasError) {
             return Text('Error');
@@ -125,7 +125,7 @@ void main() {
 
     when(
       () => client.loadGrid(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
       ),
     ).thenAnswer((_) => Future.error(''));
 
@@ -141,7 +141,7 @@ void main() {
       client: client,
       child: ApptiveGridGridBuilder(
         key: key,
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
         builder: (context, snapshot) {
           if (snapshot.hasData) {
             return Text(snapshot.data!.name);
@@ -155,7 +155,7 @@ void main() {
     final title = 'Title';
     when(
       () => client.loadGrid(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
       ),
     ).thenAnswer(
       (_) async => Grid(
@@ -174,7 +174,7 @@ void main() {
 
     verify(
       () => client.loadGrid(
-        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+        uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
       ),
     ).called(2);
   });
@@ -237,7 +237,7 @@ void main() {
         client: client,
         child: ApptiveGridGridBuilder(
           sorting: sorting,
-          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
           builder: (context, snapshot) {
             if (snapshot.hasData) {
               return Text(snapshot.data!.name);
@@ -251,7 +251,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
           sorting: sorting,
         ),
       ).thenAnswer(
@@ -282,7 +282,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: _SortingAndFilterSwitcher(
-          gridUri1: Uri.parse('/api/a/users/$user/spaces/$space/grids/$gridId'),
+          gridUri1: Uri.parse('/api/users/$user/spaces/$space/grids/$gridId'),
           sorting1: sorting,
           sorting2: [
             ApptiveGridSorting(fieldId: 'fieldId', order: SortOrder.desc)
@@ -293,7 +293,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
           sorting: any(named: 'sorting'),
         ),
       ).thenAnswer(
@@ -328,7 +328,7 @@ void main() {
         client: client,
         child: ApptiveGridGridBuilder(
           filter: filter,
-          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
           builder: (context, snapshot) {
             if (snapshot.hasData) {
               return Text(snapshot.data!.name);
@@ -342,7 +342,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
           filter: filter,
         ),
       ).thenAnswer(
@@ -374,7 +374,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: _SortingAndFilterSwitcher(
-          gridUri1: Uri.parse('/api/a/users/$user/spaces/$space/grids/$gridId'),
+          gridUri1: Uri.parse('/api/users/$user/spaces/$space/grids/$gridId'),
           filter1: filter1,
           filter2: filter2,
         ),
@@ -383,7 +383,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
           filter: any(named: 'filter'),
         ),
       ).thenAnswer(

--- a/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
+++ b/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
@@ -293,7 +293,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/$user/spaces/$space/grids/$gridId'),
           sorting: any(named: 'sorting'),
         ),
       ).thenAnswer(
@@ -328,7 +328,7 @@ void main() {
         client: client,
         child: ApptiveGridGridBuilder(
           filter: filter,
-          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/$user/spaces/$space/grids/$gridId'),
           builder: (context, snapshot) {
             if (snapshot.hasData) {
               return Text(snapshot.data!.name);
@@ -342,7 +342,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/$user/spaces/$space/grids/$gridId'),
           filter: filter,
         ),
       ).thenAnswer(
@@ -383,7 +383,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          uri: Uri.parse('/api/users/user/spaces/space/grids/gridId'),
+          uri: Uri.parse('/api/users/$user/spaces/$space/grids/$gridId'),
           filter: any(named: 'filter'),
         ),
       ).thenAnswer(

--- a/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
+++ b/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
@@ -409,6 +409,48 @@ void main() {
       ).called(2);
     });
   });
+
+  group('GridUri', () {
+    final uri = Uri.parse('uri');
+    // ignore: deprecated_member_use
+    final gridUri = GridUri.fromUri('gridUri');
+
+    test('No GridUri returns Uri as GridUri', () async {
+      final apptiveGridGridBuilder = ApptiveGridGridBuilder(
+        uri: uri,
+        builder: (_, __) => const SizedBox(),
+      );
+
+      // ignore: deprecated_member_use_from_same_package
+      expect(apptiveGridGridBuilder.gridUri.uri, equals(uri));
+      expect(apptiveGridGridBuilder.uri, equals(uri));
+    });
+
+    test('No Uri returns GridUri', () async {
+      final apptiveGridGridBuilder = ApptiveGridGridBuilder(
+        // ignore: deprecated_member_use_from_same_package
+        gridUri: gridUri,
+        builder: (_, __) => const SizedBox(),
+      );
+
+      // ignore: deprecated_member_use_from_same_package
+      expect(apptiveGridGridBuilder.gridUri.uri, equals(gridUri.uri));
+      expect(apptiveGridGridBuilder.uri, equals(gridUri.uri));
+    });
+
+    test('Uri prioritized over gridUri', () async {
+      final apptiveGridGridBuilder = ApptiveGridGridBuilder(
+        uri: uri,
+        // ignore: deprecated_member_use_from_same_package
+        gridUri: gridUri,
+        builder: (_, __) => const SizedBox(),
+      );
+
+      // ignore: deprecated_member_use_from_same_package
+      expect(apptiveGridGridBuilder.gridUri.uri, equals(uri));
+      expect(apptiveGridGridBuilder.uri, equals(uri));
+    });
+  });
 }
 
 class _SortingAndFilterSwitcher extends StatefulWidget {

--- a/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
+++ b/packages/apptive_grid_grid_builder/test/apptive_grid_grid_builder_test.dart
@@ -13,7 +13,9 @@ void main() {
   late ApptiveGridClient client;
 
   setUpAll(() {
-    registerFallbackValue(GridUri(user: 'user', space: 'space', grid: 'grid'));
+    registerFallbackValue(
+      Uri.parse('/api/a/users/user/spaces/space/grids/grid'),
+    );
     registerFallbackValue(
       [ApptiveGridSorting(fieldId: 'fieldId', order: SortOrder.asc)],
     );
@@ -29,11 +31,7 @@ void main() {
     final target = TestApp(
       client: client,
       child: ApptiveGridGridBuilder(
-        gridUri: GridUri(
-          user: user,
-          space: space,
-          grid: gridId,
-        ),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
         builder: (context, snapshot) {
           if (snapshot.hasData) {
             return Text(snapshot.data!.name);
@@ -47,7 +45,7 @@ void main() {
     final title = 'Title';
     when(
       () => client.loadGrid(
-        gridUri: GridUri(user: user, space: space, grid: gridId),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
       ),
     ).thenAnswer(
       (_) async => Grid(
@@ -69,11 +67,7 @@ void main() {
     final target = TestApp(
       client: client,
       child: ApptiveGridGridBuilder(
-        gridUri: GridUri(
-          user: user,
-          space: space,
-          grid: gridId,
-        ),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
         initialData: Grid(
           id: gridId,
           name: 'Initial Title',
@@ -94,7 +88,7 @@ void main() {
     final title = 'Title';
     when(
       () => client.loadGrid(
-        gridUri: GridUri(user: user, space: space, grid: gridId),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
       ),
     ).thenAnswer(
       (_) async => Grid(
@@ -118,11 +112,7 @@ void main() {
     final target = TestApp(
       client: client,
       child: ApptiveGridGridBuilder(
-        gridUri: GridUri(
-          user: user,
-          space: space,
-          grid: gridId,
-        ),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
         builder: (context, snapshot) {
           if (snapshot.hasError) {
             return Text('Error');
@@ -135,7 +125,7 @@ void main() {
 
     when(
       () => client.loadGrid(
-        gridUri: GridUri(user: user, space: space, grid: gridId),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
       ),
     ).thenAnswer((_) => Future.error(''));
 
@@ -151,11 +141,7 @@ void main() {
       client: client,
       child: ApptiveGridGridBuilder(
         key: key,
-        gridUri: GridUri(
-          user: user,
-          space: space,
-          grid: gridId,
-        ),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
         builder: (context, snapshot) {
           if (snapshot.hasData) {
             return Text(snapshot.data!.name);
@@ -169,7 +155,7 @@ void main() {
     final title = 'Title';
     when(
       () => client.loadGrid(
-        gridUri: GridUri(user: user, space: space, grid: gridId),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
       ),
     ).thenAnswer(
       (_) async => Grid(
@@ -188,15 +174,15 @@ void main() {
 
     verify(
       () => client.loadGrid(
-        gridUri: GridUri(user: user, space: space, grid: gridId),
+        uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
       ),
     ).called(2);
   });
 
   group('GridUri', () {
     testWidgets('Changing GridUri reloads', (tester) async {
-      final uri1 = GridUri.fromUri('/uri1');
-      final uri2 = GridUri.fromUri('/uri2');
+      final uri1 = Uri.parse('/uri1');
+      final uri2 = Uri.parse('/uri2');
       final target = TestApp(
         client: client,
         child: _SortingAndFilterSwitcher(
@@ -208,7 +194,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          gridUri: any(named: 'gridUri'),
+          uri: any(named: 'uri'),
           filter: any(named: 'filter'),
         ),
       ).thenAnswer(
@@ -228,14 +214,14 @@ void main() {
 
       verify(
         () => client.loadGrid(
-          gridUri: uri1,
+          uri: uri1,
           filter: any(named: 'filter'),
         ),
       ).called(1);
 
       verify(
         () => client.loadGrid(
-          gridUri: uri2,
+          uri: uri2,
           filter: any(named: 'filter'),
         ),
       ).called(1);
@@ -251,11 +237,7 @@ void main() {
         client: client,
         child: ApptiveGridGridBuilder(
           sorting: sorting,
-          gridUri: GridUri(
-            user: user,
-            space: space,
-            grid: gridId,
-          ),
+          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
           builder: (context, snapshot) {
             if (snapshot.hasData) {
               return Text(snapshot.data!.name);
@@ -269,7 +251,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          gridUri: GridUri(user: user, space: space, grid: gridId),
+          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
           sorting: sorting,
         ),
       ).thenAnswer(
@@ -286,7 +268,7 @@ void main() {
 
       final capturedSorting = verify(
         () => client.loadGrid(
-          gridUri: any(named: 'gridUri'),
+          uri: any(named: 'uri'),
           sorting: captureAny(named: 'sorting'),
         ),
       ).captured.first as List<ApptiveGridSorting>;
@@ -300,7 +282,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: _SortingAndFilterSwitcher(
-          gridUri1: GridUri(user: user, space: space, grid: gridId),
+          gridUri1: Uri.parse('/api/a/users/$user/spaces/$space/grids/$gridId'),
           sorting1: sorting,
           sorting2: [
             ApptiveGridSorting(fieldId: 'fieldId', order: SortOrder.desc)
@@ -311,7 +293,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          gridUri: GridUri(user: user, space: space, grid: gridId),
+          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
           sorting: any(named: 'sorting'),
         ),
       ).thenAnswer(
@@ -331,7 +313,7 @@ void main() {
 
       verify(
         () => client.loadGrid(
-          gridUri: any(named: 'gridUri'),
+          uri: any(named: 'uri'),
           sorting: any(named: 'sorting'),
         ),
       ).called(2);
@@ -346,11 +328,7 @@ void main() {
         client: client,
         child: ApptiveGridGridBuilder(
           filter: filter,
-          gridUri: GridUri(
-            user: user,
-            space: space,
-            grid: gridId,
-          ),
+          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
           builder: (context, snapshot) {
             if (snapshot.hasData) {
               return Text(snapshot.data!.name);
@@ -364,7 +342,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          gridUri: GridUri(user: user, space: space, grid: gridId),
+          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
           filter: filter,
         ),
       ).thenAnswer(
@@ -381,7 +359,7 @@ void main() {
 
       final capturedSorting = verify(
         () => client.loadGrid(
-          gridUri: any(named: 'gridUri'),
+          uri: any(named: 'uri'),
           filter: captureAny(named: 'filter'),
         ),
       ).captured.first as ApptiveGridFilter;
@@ -396,7 +374,7 @@ void main() {
       final target = TestApp(
         client: client,
         child: _SortingAndFilterSwitcher(
-          gridUri1: GridUri(user: user, space: space, grid: gridId),
+          gridUri1: Uri.parse('/api/a/users/$user/spaces/$space/grids/$gridId'),
           filter1: filter1,
           filter2: filter2,
         ),
@@ -405,7 +383,7 @@ void main() {
       final title = 'Title';
       when(
         () => client.loadGrid(
-          gridUri: GridUri(user: user, space: space, grid: gridId),
+          uri: Uri.parse('/api/a/users/user/spaces/space/grids/gridId'),
           filter: any(named: 'filter'),
         ),
       ).thenAnswer(
@@ -425,7 +403,7 @@ void main() {
 
       verify(
         () => client.loadGrid(
-          gridUri: any(named: 'gridUri'),
+          uri: any(named: 'uri'),
           filter: any(named: 'filter'),
         ),
       ).called(2);
@@ -450,8 +428,8 @@ class _SortingAndFilterSwitcher extends StatefulWidget {
   final ApptiveGridFilter? filter1;
   final ApptiveGridFilter? filter2;
 
-  final GridUri gridUri1;
-  final GridUri? gridUri2;
+  final Uri gridUri1;
+  final Uri? gridUri2;
 
   @override
   State<_SortingAndFilterSwitcher> createState() =>
@@ -461,7 +439,7 @@ class _SortingAndFilterSwitcher extends StatefulWidget {
 class _SortingAndFilterSwitcherState extends State<_SortingAndFilterSwitcher> {
   late List<ApptiveGridSorting>? _sorting;
   late ApptiveGridFilter? _filter;
-  late GridUri _gridUri;
+  late Uri _gridUri;
 
   @override
   void initState() {
@@ -490,7 +468,7 @@ class _SortingAndFilterSwitcherState extends State<_SortingAndFilterSwitcher> {
         ApptiveGridGridBuilder(
           sorting: _sorting,
           filter: _filter,
-          gridUri: _gridUri,
+          uri: _gridUri,
           builder: (_, __) => const SizedBox(),
         ),
       ],


### PR DESCRIPTION
I know this is once again a really big refactor in terms of line counts but I don't really see a point in splitting this up into multiple PRs as 
1. The line count would be the same
2. Jobs would not run successful as everything depends on everything

So feel free to section your review into chunks. I guess the `viewed` feature of github helps and you can split in packages.

---
## What did I do

I deprecated the `ApptiveGridUri` as they either assume a lot about the format of a grid or just parse into uri, so there is no real point in using them over regular uris. This forces/encourages users of the packages to use the ApptiveLinks more which is good as they are independent of the format of the uris.

### What to look out for
You'll find basically three types of changes in this PR
- Deprecation notices
- Refactors (most in tests) to changes usages from using the now deprecated `ApptiveGridUri` to using plain `Uri`
- Compatibility refactors for `ApptiveGridForm` and `ApptiveGridGridBuilder` to still support the old format.

--- 
I think we should keep this for now but remove all Deprecated things in the api before we do our first `1.0.0` release however in the next stable (non `-alpha`) releases they should still be in there