### PR TITLE
Update apptive_grid_web_apptive example

### DIFF
--- a/packages/apptive_grid_web_apptive/CHANGELOG.md
+++ b/packages/apptive_grid_web_apptive/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.3-alpha.3
+* Update example to style it with `apptive_grid_theme`
+
 ## 0.0.3-alpha.2
 * Upgraded to `flutter_lints 2`
 

--- a/packages/apptive_grid_web_apptive/example/lib/apptive_grid_pie_chart.dart
+++ b/packages/apptive_grid_web_apptive/example/lib/apptive_grid_pie_chart.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: public_member_api_docs
 
+import 'package:apptive_grid_theme/apptive_grid_theme.dart';
 import 'package:apptive_grid_web_apptive/apptive_grid_web_apptive.dart';
 import 'package:flutter/material.dart';
 import 'package:pie_chart/pie_chart.dart';
@@ -103,6 +104,13 @@ class _ApptiveGridPieChartState extends State<ApptiveGridPieChart> {
                       showLegendsInRow: true,
                       legendPosition: LegendPosition.bottom,
                     ),
+                    colorList: [
+                      ApptiveGridColors.grid,
+                      ApptiveGridColors.form,
+                      ApptiveGridColors.kanban,
+                      ApptiveGridColors.calendar,
+                      ..._materialDefaultColors,
+                    ],
                   ),
                 ],
               ),
@@ -202,3 +210,28 @@ class _FieldSelectorState extends State<FieldSelector> {
     );
   }
 }
+
+// Colors.primary with some colors commented out that are too close to already defined ApptiveGrid Colors
+const _materialDefaultColors = [
+  //Colors.red,
+  Colors.pink,
+  Colors.purple,
+  //Colors.deepPurple,
+  //Colors.indigo,
+  //Colors.blue,
+  //Colors.lightBlue,
+  Colors.cyan,
+  //Colors.teal,
+  //Colors.green,
+  //Colors.lightGreen,
+  Colors.lime,
+  //Colors.yellow,
+  //Colors.amber,
+  //Colors.orange,
+  //Colors.deepOrange,
+  //Colors.brown,
+  // The grey swatch is intentionally omitted because when picking a color
+  // randomly from this list to colorize an application, picking grey suddenly
+  // makes the app look disabled.
+  Colors.blueGrey,
+];

--- a/packages/apptive_grid_web_apptive/example/lib/main.dart
+++ b/packages/apptive_grid_web_apptive/example/lib/main.dart
@@ -1,7 +1,8 @@
 // ignore_for_file: public_member_api_docs
 
-import 'package:apptive_grid_web_apptive_example/apptive_grid_pie_chart.dart';
+import 'package:apptive_grid_theme/apptive_grid_theme.dart';
 import 'package:apptive_grid_web_apptive/apptive_grid_web_apptive.dart';
+import 'package:apptive_grid_web_apptive_example/apptive_grid_pie_chart.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -13,9 +14,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'ApptiveGrid',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
+      theme: ApptiveGridTheme(brightness: Brightness.light).theme(),
       home: Scaffold(
         body: ApptiveGridWebApptive(
           builder: (context, event) {

--- a/packages/apptive_grid_web_apptive/example/pubspec.yaml
+++ b/packages/apptive_grid_web_apptive/example/pubspec.yaml
@@ -24,6 +24,7 @@ dependency_overrides:
   pointycastle: 3.1.1
 
 dependencies:
+  apptive_grid_theme: ^0.1.1
   apptive_grid_web_apptive:
     path: ../
   flutter:


### PR DESCRIPTION
Updated the apptive_grid_web_apptive example to use apptive_grid_theme and make the colors in general a bit fitting in the web app.
This version is what was used to build the fixed version of the pie chart apptive which will land on apptive_grid soon