### PR TITLE
Fix created by type parsing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,3 +68,25 @@ jobs:
 
       - name: Build iOS Examples
         run: melos run build:ios
+
+  report:
+    name: Report to Slack
+    needs: [
+      quality,
+      android_examples,
+      ios_examples
+    ]
+    if: ${{ always() && !cancelled() && github.ref_name == 'main'}}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: martialonline/workflow-status@v3
+        id: check
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: 'ApptiveGrid Flutter Packages'
+          SLACK_ICON: "https://apptiveattachmentsprod-apptiveattachmentbucket-1g9k6859i00z1.s3.eu-central-1.amazonaws.com/8398ca4c-c339-4c3e-89c2-8d0495e4b868"
+          SLACK_COLOR: ${{ steps.check.outputs.status }}
+          SLACK_FOOTER: ''

--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.11.1+1
+* Fix parsing of GridField with `createdBy`. Convert deprecated `userReference` type into a static variable pointing to the correct `createdBy` type
+
 ## 0.11.1
 * Resize Images in Isolate when uploading Attachments
 

--- a/packages/apptive_grid_core/lib/model/data_entity.dart
+++ b/packages/apptive_grid_core/lib/model/data_entity.dart
@@ -78,6 +78,9 @@ abstract class DataEntity<T, S> with FilterableMixin {
           jsonValue: json,
           gridUri: field.schema['items']['gridUri'],
         );
+      // ignore: deprecated_member_use_from_same_package
+      case DataType.userReference:
+      // ignore: no_duplicate_case_values
       case DataType.createdBy:
         return CreatedByDataEntity.fromJson(json);
       case DataType.user:

--- a/packages/apptive_grid_core/lib/model/data_entity.dart
+++ b/packages/apptive_grid_core/lib/model/data_entity.dart
@@ -78,8 +78,6 @@ abstract class DataEntity<T, S> with FilterableMixin {
           jsonValue: json,
           gridUri: field.schema['items']['gridUri'],
         );
-      // ignore: deprecated_member_use_from_same_package
-      case DataType.userReference:
       case DataType.createdBy:
         return CreatedByDataEntity.fromJson(json);
       case DataType.user:

--- a/packages/apptive_grid_core/lib/model/data_type.dart
+++ b/packages/apptive_grid_core/lib/model/data_type.dart
@@ -38,10 +38,6 @@ enum DataType {
   /// Type for Multi Cross References
   multiCrossReference(backendName: 'references'),
 
-  /// Type for UserReferences. Used for createdBy
-  @Deprecated('Use createdBy instead')
-  userReference(backendName: 'createdby'),
-
   /// Type for CreatedBy.
   createdBy(backendName: 'createdby'),
 
@@ -55,4 +51,8 @@ enum DataType {
 
   /// The name that is used in the ApptiveGridBackend for this [DataType]
   final String backendName;
+
+  /// Deprecated Type for UserReferences. Used for createdBy
+  @Deprecated('Use createdBy instead')
+  static const DataType userReference = DataType.createdBy;
 }

--- a/packages/apptive_grid_core/pubspec.yaml
+++ b/packages/apptive_grid_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_core
 description: Core Library for ApptiveGrid used to provide general ApptiveGrid functionality to other Packages or Apps
-version: 0.11.1
+version: 0.11.1+1
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_core
 

--- a/packages/apptive_grid_core/test/grid_field_test.dart
+++ b/packages/apptive_grid_core/test/grid_field_test.dart
@@ -53,5 +53,49 @@ void main() {
 
       expect(GridField.fromJson(fromJson.toJson()), equals(fromJson));
     });
+
+    test('CreatedBy type is parsed correctly', () {
+      final json = {
+        "key": null,
+        "id": "fieldId",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "displayValue": {"type": "string", "format": "string"},
+            "id": {"type": "string", "format": "string"},
+            "type": {"type": "string", "format": "string"},
+            "name": {"type": "string", "format": "string"}
+          },
+          "objectType": "userReference"
+        },
+        "name": "Created by",
+        "type": {
+          "name": "createdby",
+          "typeName": "createdby",
+          "componentTypes": ["textfield"]
+        },
+        "_links": {
+          "patch": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/fields/fieldId",
+            "method": "patch"
+          },
+          "query": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/fields/fieldId/query",
+            "method": "get"
+          },
+          "self": {
+            "href":
+                "/api/users/userId/spaces/spaceId/grids/gridId/fields/fieldId",
+            "method": "get"
+          }
+        }
+      };
+
+      final fromJson = GridField.fromJson(json);
+
+      expect(fromJson.type, DataType.createdBy);
+    });
   });
 }

--- a/packages/apptive_grid_form/lib/widgets/form_widget/form_widget.dart
+++ b/packages/apptive_grid_form/lib/widgets/form_widget/form_widget.dart
@@ -53,6 +53,9 @@ Widget fromModel(FormComponent component) {
       return MultiCrossReferenceFormWidget(
         component: component.cast<MultiCrossReferenceDataEntity>(),
       );
+    // ignore: deprecated_member_use
+    case DataType.userReference:
+    // ignore: no_duplicate_case_values
     case DataType.createdBy:
       return const CreatedByFormWidget();
     case DataType.user:

--- a/packages/apptive_grid_form/lib/widgets/form_widget/form_widget.dart
+++ b/packages/apptive_grid_form/lib/widgets/form_widget/form_widget.dart
@@ -53,8 +53,6 @@ Widget fromModel(FormComponent component) {
       return MultiCrossReferenceFormWidget(
         component: component.cast<MultiCrossReferenceDataEntity>(),
       );
-    // ignore: deprecated_member_use
-    case DataType.userReference:
     case DataType.createdBy:
       return const CreatedByFormWidget();
     case DataType.user:


### PR DESCRIPTION
Before this change the `DataType` of a `GridField` was parsed by taking the first entry with the according `backendName`

```dart
return GridField(
      ...
      type: DataType.values
          .firstWhere((type) => type.backendName == json['type']['name']),
      ...
    );
```


Unfortunately the deprecated `DataType.userReference` and the desired `DataType.createdBy` type both defined the backendName as `createdBy` but due to the order of definition it would always return `DataType.userReference`

As a fix `userReference` is changed from a enum type to a static variable of `DataType` (thanks to dart rich enums) which points to `DataType.createdBy` which produces the desired deprecation behaviour